### PR TITLE
fix: return after handler error to avoid invalid read

### DIFF
--- a/plugins/gateway/cloudrun/http.go
+++ b/plugins/gateway/cloudrun/http.go
@@ -73,6 +73,7 @@ func httpHandler(handler handler.TriggerHandler) func(ctx *fasthttp.RequestCtx) 
 
 		if err != nil {
 			ctx.Error(fmt.Sprintf("Error handling HTTP Request: %v", err), 500)
+			return
 		}
 		// responseBody, _ := ioutil.ReadAll(response.Body)
 		if response.Header != nil {

--- a/plugins/gateway/dev/gateway.go
+++ b/plugins/gateway/dev/gateway.go
@@ -63,6 +63,12 @@ func httpHandler(handler handler.TriggerHandler) func(ctx *fasthttp.RequestCtx) 
 		// Handle HTTP Request Types
 		response, err := handler.HandleHttpRequest(httpReq)
 
+		if err != nil {
+			// TODO: Redact message in production
+			ctx.Error(err.Error(), 500)
+			return
+		}
+
 		if response.Header != nil {
 			response.Header.CopyTo(&ctx.Response.Header)
 		}
@@ -72,11 +78,6 @@ func httpHandler(handler handler.TriggerHandler) func(ctx *fasthttp.RequestCtx) 
 
 		ctx.Response.SetBody(response.Body)
 		ctx.Response.SetStatusCode(response.StatusCode)
-
-		if err != nil {
-			// TODO: Redact message in production
-			ctx.Error(err.Error(), 500)
-		}
 	}
 }
 


### PR DESCRIPTION
Without this, the membrane crashes in local dev when the template returns an HTTP error status