### PR TITLE
Trigger API client generation

### DIFF
--- a/.github/workflows/generate-sdks.yaml
+++ b/.github/workflows/generate-sdks.yaml
@@ -1,0 +1,19 @@
+name: Generate SDKs
+on:
+  release:
+    types: [published]
+
+jobs:
+  # Bump the membrane version
+  generate_sdks:
+    name: Signal base SDK repo for auto regen
+    runs-on: ubuntu-latest
+    steps:
+      - name: Signal base SDK repo
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.NITRIC_BOT_TOKEN }}
+          repository: nitrictech/base-sdk
+          event-type: generate
+          client-payload: '{ "prerelease": ${{ github.event.release.prerelease }}, "version": "${{ github.event.release.tag_name }}" }'
+  

--- a/.github/workflows/generate-sdks.yaml
+++ b/.github/workflows/generate-sdks.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.NITRIC_BOT_TOKEN }}
-          repository: nitrictech/base-sdk
+          repository: nitrictech/apis
           event-type: generate
           client-payload: >
             {

--- a/.github/workflows/generate-sdks.yaml
+++ b/.github/workflows/generate-sdks.yaml
@@ -15,5 +15,9 @@ jobs:
           token: ${{ secrets.NITRIC_BOT_TOKEN }}
           repository: nitrictech/base-sdk
           event-type: generate
-          client-payload: '{ "prerelease": ${{ github.event.release.prerelease }}, "version": "${{ github.event.release.tag_name }}" }'
+          client-payload: >
+            {
+              "prerelease": ${{ github.event.release.prerelease }}, 
+              "tag_name": "${{ github.event.release.tag_name }}"
+            }
   


### PR DESCRIPTION
Trigger SDK generation on release publish.

> This depends on: https://github.com/nitrictech/base-sdk/pull/5 and remaining sdk generation branches.