### PR TITLE
feat: add aws ses emails service

### DIFF
--- a/makefile
+++ b/makefile
@@ -194,5 +194,7 @@ generate-mocks:
 	@echo Generating Mock Clients
 	@mkdir -p mocks/mock_secret_manager
 	@mkdir -p mocks/secrets_manager
+	@mkdir -p mocks/aws_ses
 	@go run github.com/golang/mock/mockgen github.com/nitric-dev/membrane/pkg/plugins/secret/secret_manager SecretManagerClient > mocks/mock_secret_manager/mock.go
 	@go run github.com/golang/mock/mockgen github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface SecretsManagerAPI > mocks/secrets_manager/mock.go
+	@go run github.com/golang/mock/mockgen github.com/aws/aws-sdk-go/service/ses/sesiface SESAPI > mocks/aws_ses/mock.go

--- a/pkg/adapters/grpc/email_grpc.go
+++ b/pkg/adapters/grpc/email_grpc.go
@@ -1,0 +1,71 @@
+// Copyright 2021 Nitric Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"context"
+
+	pb "github.com/nitric-dev/membrane/interfaces/nitric/v1"
+	"github.com/nitric-dev/membrane/pkg/plugins/emails"
+	"google.golang.org/grpc/codes"
+)
+
+// EmailServiceServer - GRPC Interface for registered Nitric Email Plugins
+type EmailServiceServer struct {
+	pb.UnimplementedEmailServiceServer
+	emailPlugin emails.EmailService
+}
+
+func (s *EmailServiceServer) checkPluginRegistered() error {
+	if s.emailPlugin == nil {
+		return NewPluginNotRegisteredError("Email")
+	}
+
+	return nil
+}
+
+// Send - Send an email using the provided inputs
+func (s *EmailServiceServer) Send(ctx context.Context, req *pb.EmailSendRequest) (*pb.EmailSendResponse, error) {
+	if err := s.checkPluginRegistered(); err != nil {
+		return nil, err
+	}
+
+	if err := req.ValidateAll(); err != nil {
+		return nil, newGrpcErrorWithCode(codes.InvalidArgument, "EmailService.Send", err)
+	}
+
+	dest := emails.EmailDestination{
+		To:  req.To,
+		Cc:  req.Cc,
+		Bcc: req.Bcc,
+	}
+
+	body := emails.EmailBody{
+		Text: &req.Body.Text,
+		Html: &req.Body.Html,
+	}
+
+	if err := s.emailPlugin.Send(req.From, dest, req.Subject, body); err == nil {
+		return &pb.EmailSendResponse{}, nil
+	} else {
+		return nil, NewGrpcError("EmailService.Send", err)
+	}
+}
+
+func NewEmailServiceServer(emailPlugin emails.EmailService) pb.EmailServiceServer {
+	return &EmailServiceServer{
+		emailPlugin: emailPlugin,
+	}
+}

--- a/pkg/plugins/emails/dev/email.go
+++ b/pkg/plugins/emails/dev/email.go
@@ -1,0 +1,54 @@
+// Copyright 2021 Nitric Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package email_service
+
+import (
+	"fmt"
+
+	"github.com/nitric-dev/membrane/pkg/plugins/errors"
+	"github.com/nitric-dev/membrane/pkg/plugins/errors/codes"
+
+	"github.com/nitric-dev/membrane/pkg/plugins/emails"
+)
+
+type DevEmailService struct {
+	emails.UnimplementedEmailService
+}
+
+func isEmpty(strArray []string) bool {
+	return len(strArray) == 0
+}
+
+func (s *DevEmailService) Send(from string, dest emails.EmailDestination, subject string, body emails.EmailBody) error {
+	newErr := errors.ErrorsWithScope(
+		"DevEmailService.Send",
+		fmt.Sprintf("from=%s", from),
+	)
+
+	// At least one destination email address is required.
+	if isEmpty(dest.To) && isEmpty(dest.Cc) && isEmpty(dest.Bcc) {
+		return newErr(codes.InvalidArgument, "no recipients specified", fmt.Errorf("one of to, cc or bcc must be specified"))
+	}
+
+	// Just print the request so basic debugging/testing can be performed.
+	// Future enhancement may allow SMTP setting or similar be used to send real emails.
+	fmt.Printf("Email sent from: %s, destination: %v, subject: %s, body text: %s, body html: %s \n", from, dest, subject, *body.Text, *body.Html)
+
+	return nil
+}
+
+func New() (emails.EmailService, error) {
+	return &DevEmailService{}, nil
+}

--- a/pkg/plugins/emails/dev/email_suite_test.go
+++ b/pkg/plugins/emails/dev/email_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Nitric Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package email_service_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEmail(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Dev Email Service Suite")
+}

--- a/pkg/plugins/emails/dev/email_test.go
+++ b/pkg/plugins/emails/dev/email_test.go
@@ -1,0 +1,82 @@
+// Copyright 2021 Nitric Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package email_service_test
+
+import (
+	"github.com/nitric-dev/membrane/pkg/plugins/emails"
+	email_service "github.com/nitric-dev/membrane/pkg/plugins/emails/dev"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Email", func() {
+
+	emailPlugin, err := email_service.New()
+	if err != nil {
+		panic(err)
+	}
+
+	Context("Send", func() {
+		text := "some text"
+		html := "<h1>some html</h1>"
+		body := emails.EmailBody{
+			Text: &text,
+			Html: &html,
+		}
+
+		When("A 'to' address is set", func() {
+			dest := emails.EmailDestination{
+				To: []string{"someoneelse@example.com"},
+			}
+
+			It("Should send the email", func() {
+				err := emailPlugin.Send("someone@example.com", dest, "some subject", body)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+
+		When("A 'cc' address is set", func() {
+			dest := emails.EmailDestination{
+				Cc: []string{"someoneelse@example.com"},
+			}
+
+			It("Should send the email", func() {
+				err := emailPlugin.Send("someone@example.com", dest, "some subject", body)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+
+		When("A 'bcc' address is set", func() {
+			dest := emails.EmailDestination{
+				Bcc: []string{"someoneelse@example.com"},
+			}
+
+			It("Should send the email", func() {
+				err := emailPlugin.Send("someone@example.com", dest, "some subject", body)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+
+		When("A no destination addresses are set", func() {
+			dest := emails.EmailDestination{}
+
+			It("Should error", func() {
+				err := emailPlugin.Send("someone@example.com", dest, "some subject", body)
+				Expect(err).Should(HaveOccurred())
+			})
+		})
+	})
+})

--- a/pkg/plugins/emails/plugin.go
+++ b/pkg/plugins/emails/plugin.go
@@ -1,0 +1,40 @@
+// Copyright 2021 Nitric Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package emails
+
+import "fmt"
+
+type EmailDestination struct {
+	To  []string
+	Cc  []string
+	Bcc []string
+}
+
+type EmailBody struct {
+	Text *string
+	Html *string
+}
+
+type EmailService interface {
+	Send(from string, dest EmailDestination, subject string, body EmailBody) error
+}
+
+type UnimplementedEmailService struct {
+	EmailService
+}
+
+func (e *UnimplementedEmailService) Send(from string, dest EmailDestination, subject string, body EmailBody) error {
+	return fmt.Errorf("UNIMPLEMENTED")
+}

--- a/pkg/plugins/emails/ses/ses.go
+++ b/pkg/plugins/emails/ses/ses.go
@@ -1,0 +1,176 @@
+// Copyright 2021 Nitric Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ses_service
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/aws/aws-sdk-go/service/ses/sesiface"
+	"github.com/nitric-dev/membrane/pkg/plugins/emails"
+	"github.com/nitric-dev/membrane/pkg/plugins/errors"
+	"github.com/nitric-dev/membrane/pkg/plugins/errors/codes"
+	"github.com/nitric-dev/membrane/pkg/utils"
+)
+
+const CharSet = "UTF-8"
+
+type SesEmailService struct {
+	emails.UnimplementedEmailService
+	client sesiface.SESAPI
+}
+
+func destToAwsDest(dest emails.EmailDestination) (*ses.Destination, error) {
+	if len(dest.To)+len(dest.Cc)+len(dest.Bcc) == 0 {
+		return nil, fmt.Errorf("at least one destination email address (to, cc, or bcc) is required")
+	}
+
+	destination := ses.Destination{}
+	// To Addresses
+	if len(dest.To) > 0 {
+		destination.ToAddresses = make([]*string, 0, len(dest.To))
+		for i := 0; i < len(dest.To); i++ {
+			destination.ToAddresses = append(destination.ToAddresses, aws.String(dest.To[i]))
+		}
+	}
+	// Cc Addresses
+	if len(dest.Cc) > 0 {
+		destination.CcAddresses = make([]*string, 0, len(dest.Cc))
+		for i := 0; i < len(dest.Cc); i++ {
+			destination.CcAddresses = append(destination.CcAddresses, aws.String(dest.Cc[i]))
+		}
+	}
+	// Bcc Addresses
+	if len(dest.Bcc) > 0 {
+		destination.BccAddresses = make([]*string, 0, len(dest.Bcc))
+		for i := 0; i < len(dest.Bcc); i++ {
+			destination.BccAddresses = append(destination.BccAddresses, aws.String(dest.Bcc[i]))
+		}
+	}
+
+	return &destination, nil
+}
+
+// Send an email
+func (s *SesEmailService) Send(from string, dest emails.EmailDestination, subject string, body emails.EmailBody) error {
+	newErr := errors.ErrorsWithScope(
+		"SesEmailService.Send",
+		fmt.Sprintf("from=%s", from),
+	)
+
+	destination, err := destToAwsDest(dest)
+	if err != nil {
+		return newErr(
+			codes.InvalidArgument,
+			"failed to determine message destination",
+			err,
+		)
+	}
+
+	sendInput := &ses.SendEmailInput{
+		Source:      aws.String(from),
+		Destination: destination,
+		Message: &ses.Message{
+			Body: &ses.Body{
+				Html: &ses.Content{
+					Charset: aws.String(CharSet),
+					Data:    body.Html,
+				},
+				Text: &ses.Content{
+					Charset: aws.String(CharSet),
+					Data:    body.Text,
+				},
+			},
+			Subject: &ses.Content{
+				Charset: aws.String(CharSet),
+				Data:    aws.String(subject),
+			},
+		},
+	}
+
+	_, err = s.client.SendEmail(sendInput)
+
+	// TODO: Consider sending message id in response.
+	//result, err := s.client.SendEmail(sendInput)
+	//result.MessageId
+
+	// Display error messages if they occur.
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case ses.ErrCodeMessageRejected:
+				return newErr(
+					codes.InvalidArgument,
+					"email message rejected",
+					aerr,
+				)
+			case ses.ErrCodeMailFromDomainNotVerifiedException:
+				return newErr(
+					codes.FailedPrecondition,
+					"email from domain not verified",
+					aerr,
+				)
+			case ses.ErrCodeConfigurationSetDoesNotExistException:
+				// TODO: consider FailedPrecondition.
+				return newErr(
+					codes.Internal,
+					"configuration set does not exist",
+					aerr,
+				)
+			default:
+				return newErr(
+					codes.Internal,
+					"failed to send email",
+					aerr,
+				)
+			}
+		} else {
+			return newErr(
+				codes.Unknown,
+				"failed to send email",
+				aerr,
+			)
+		}
+	}
+	return nil
+}
+
+// New - Create a new SES email service plugin
+func New() (emails.EmailService, error) {
+	awsRegion := utils.GetEnv("AWS_REGION", "us-east-1")
+
+	sess, sessionError := session.NewSession(&aws.Config{
+		Region: aws.String(awsRegion),
+	})
+
+	if sessionError != nil {
+		return nil, fmt.Errorf("error creating new AWS session %v", sessionError)
+	}
+
+	sesClient := ses.New(sess)
+
+	return &SesEmailService{
+		client: sesClient,
+	}, nil
+}
+
+func NewWithClient(client sesiface.SESAPI) (emails.EmailService, error) {
+	return &SesEmailService{
+		client: client,
+	}, nil
+}

--- a/pkg/plugins/emails/ses/ses_suite_test.go
+++ b/pkg/plugins/emails/ses/ses_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Nitric Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ses_service
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSES(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SES Emails Service Suite")
+}

--- a/pkg/plugins/emails/ses/ses_test.go
+++ b/pkg/plugins/emails/ses/ses_test.go
@@ -1,0 +1,153 @@
+// Copyright 2021 Nitric Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ses_service
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/golang/mock/gomock"
+	mock_sesiface "github.com/nitric-dev/membrane/mocks/aws_ses"
+	"github.com/nitric-dev/membrane/pkg/plugins/emails"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SES", func() {
+	When("Send", func() {
+		When("Given a valid set of email request attributes", func() {
+			from := "from@example.com"
+			to := "to@example.com"
+			subject := "the subject"
+			textBody := "the body"
+			htmlBody := "<p>the html body</p>"
+
+			When("Sending the email", func() {
+				crtl := gomock.NewController(GinkgoT())
+				mockSes := mock_sesiface.NewMockSESAPI(crtl)
+				emailsPlugin, _ := NewWithClient(mockSes)
+				It("Should successfully provide the to address to the SES API", func() {
+					By("Calling send with the correct arguments")
+					mockSes.EXPECT().SendEmail(&ses.SendEmailInput{
+						Source: aws.String("from@example.com"),
+						Destination: &ses.Destination{
+							ToAddresses:  []*string{aws.String("to@example.com")},
+							CcAddresses:  nil,
+							BccAddresses: nil,
+						},
+						Message: &ses.Message{
+							Body: &ses.Body{
+								Html: &ses.Content{
+									Charset: aws.String(CharSet),
+									Data:    aws.String("<p>the html body</p>"),
+								},
+								Text: &ses.Content{
+									Charset: aws.String(CharSet),
+									Data:    aws.String("the body"),
+								},
+							},
+							Subject: &ses.Content{
+								Charset: aws.String(CharSet),
+								Data:    aws.String("the subject"),
+							},
+						},
+					}).Times(1).Return(nil, nil)
+
+					err := emailsPlugin.Send(from, emails.EmailDestination{To: []string{to}}, subject, emails.EmailBody{
+						Text: &textBody,
+						Html: &htmlBody,
+					})
+					By("Not returning an error")
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+			})
+		})
+
+		When("Given no destination addresses", func() {
+			from := "from@example.com"
+			subject := "the subject"
+			textBody := "the body"
+			htmlBody := "<p>the html body</p>"
+
+			When("Sending the email", func() {
+				crtl := gomock.NewController(GinkgoT())
+				mockSes := mock_sesiface.NewMockSESAPI(crtl)
+				emailsPlugin, _ := NewWithClient(mockSes)
+				It("Should successfully provide the to address to the SES API", func() {
+					By("Calling not calling send on the SES API")
+
+					err := emailsPlugin.Send(from, emails.EmailDestination{To: []string{}}, subject, emails.EmailBody{
+						Text: &textBody,
+						Html: &htmlBody,
+					})
+
+					By("Returning an error")
+					Expect(err).Should(HaveOccurred())
+				})
+			})
+		})
+
+		When("AWS SES returns an error", func() {
+			from := "from@example.com"
+			to := "to@example.com"
+			subject := "the subject"
+			textBody := "the body"
+			htmlBody := "<p>the html body</p>"
+
+			When("Sending the email", func() {
+				crtl := gomock.NewController(GinkgoT())
+				mockSes := mock_sesiface.NewMockSESAPI(crtl)
+				emailsPlugin, _ := NewWithClient(mockSes)
+				It("Should successfully provide the to address to the SES API", func() {
+					By("Calling SES API")
+					mockSes.EXPECT().SendEmail(&ses.SendEmailInput{
+						Source: aws.String("from@example.com"),
+						Destination: &ses.Destination{
+							ToAddresses:  []*string{aws.String("to@example.com")},
+							CcAddresses:  nil,
+							BccAddresses: nil,
+						},
+						Message: &ses.Message{
+							Body: &ses.Body{
+								Html: &ses.Content{
+									Charset: aws.String(CharSet),
+									Data:    aws.String("<p>the html body</p>"),
+								},
+								Text: &ses.Content{
+									Charset: aws.String(CharSet),
+									Data:    aws.String("the body"),
+								},
+							},
+							Subject: &ses.Content{
+								Charset: aws.String(CharSet),
+								Data:    aws.String("the subject"),
+							},
+						},
+					}).Times(1).Return(nil, awserr.New(ses.ErrCodeMessageRejected, "test error", fmt.Errorf("internal test error")))
+
+					err := emailsPlugin.Send(from, emails.EmailDestination{To: []string{to}}, subject, emails.EmailBody{
+						Text: &textBody,
+						Html: &htmlBody,
+					})
+
+					By("Returning an error")
+					Expect(err).Should(HaveOccurred())
+				})
+			})
+		})
+	})
+})

--- a/pkg/providers/aws/membrane.go
+++ b/pkg/providers/aws/membrane.go
@@ -23,14 +23,15 @@ import (
 
 	"github.com/nitric-dev/membrane/pkg/membrane"
 	dynamodb_service "github.com/nitric-dev/membrane/pkg/plugins/document/dynamodb"
+	ses_service "github.com/nitric-dev/membrane/pkg/plugins/emails/ses"
 	sns_service "github.com/nitric-dev/membrane/pkg/plugins/events/sns"
 	"github.com/nitric-dev/membrane/pkg/plugins/gateway"
 	ecs_service "github.com/nitric-dev/membrane/pkg/plugins/gateway/ecs"
 	lambda_service "github.com/nitric-dev/membrane/pkg/plugins/gateway/lambda"
 	sqs_service "github.com/nitric-dev/membrane/pkg/plugins/queue/sqs"
+	secrets_manager_secret_service "github.com/nitric-dev/membrane/pkg/plugins/secret/secrets_manager"
 	s3_service "github.com/nitric-dev/membrane/pkg/plugins/storage/s3"
 	"github.com/nitric-dev/membrane/pkg/utils"
-	secrets_manager_secret_service "github.com/nitric-dev/membrane/pkg/plugins/secret/secrets_manager"
 )
 
 func main() {
@@ -48,19 +49,21 @@ func main() {
 	default:
 		gatewayPlugin, _ = ecs_service.New()
 	}
-	secretPlugin, _ := secrets_manager_secret_service.New()
 	documentPlugin, _ := dynamodb_service.New()
+	emailPlugin, _ := ses_service.New()
 	eventsPlugin, _ := sns_service.New()
 	queuePlugin, _ := sqs_service.New()
+	secretPlugin, _ := secrets_manager_secret_service.New()
 	storagePlugin, _ := s3_service.New()
 
 	m, err := membrane.New(&membrane.MembraneOptions{
 		DocumentPlugin: documentPlugin,
+		EmailsPlugin:   emailPlugin,
 		EventsPlugin:   eventsPlugin,
 		GatewayPlugin:  gatewayPlugin,
 		QueuePlugin:    queuePlugin,
-		StoragePlugin:  storagePlugin,
 		SecretPlugin:   secretPlugin,
+		StoragePlugin:  storagePlugin,
 	})
 
 	if err != nil {

--- a/pkg/providers/aws/plugin.go
+++ b/pkg/providers/aws/plugin.go
@@ -17,12 +17,16 @@ package main
 import (
 	"github.com/nitric-dev/membrane/pkg/plugins/document"
 	dynamodb_service "github.com/nitric-dev/membrane/pkg/plugins/document/dynamodb"
+	"github.com/nitric-dev/membrane/pkg/plugins/emails"
+	ses_service "github.com/nitric-dev/membrane/pkg/plugins/emails/ses"
 	"github.com/nitric-dev/membrane/pkg/plugins/events"
 	sns_service "github.com/nitric-dev/membrane/pkg/plugins/events/sns"
 	"github.com/nitric-dev/membrane/pkg/plugins/gateway"
 	lambda_service "github.com/nitric-dev/membrane/pkg/plugins/gateway/lambda"
 	"github.com/nitric-dev/membrane/pkg/plugins/queue"
 	sqs_service "github.com/nitric-dev/membrane/pkg/plugins/queue/sqs"
+	"github.com/nitric-dev/membrane/pkg/plugins/secret"
+	secrets_manager_secret_service "github.com/nitric-dev/membrane/pkg/plugins/secret/secrets_manager"
 	"github.com/nitric-dev/membrane/pkg/plugins/storage"
 	s3_service "github.com/nitric-dev/membrane/pkg/plugins/storage/s3"
 	"github.com/nitric-dev/membrane/pkg/providers"
@@ -40,6 +44,11 @@ func (p *AWSServiceFactory) NewDocumentService() (document.DocumentService, erro
 	return dynamodb_service.New()
 }
 
+// NewEmailService - Returns AWS SES based emails plugin
+func (p *AWSServiceFactory) NewEmailService() (emails.EmailService, error) {
+	return ses_service.New()
+}
+
 // NewEventService - Returns AWS SNS based events plugin
 func (p *AWSServiceFactory) NewEventService() (events.EventService, error) {
 	return sns_service.New()
@@ -53,6 +62,11 @@ func (p *AWSServiceFactory) NewGatewayService() (gateway.GatewayService, error) 
 // NewQueueService - Returns AWS SQS based queue plugin
 func (p *AWSServiceFactory) NewQueueService() (queue.QueueService, error) {
 	return sqs_service.New()
+}
+
+// NewStorageService - Returns AWS Secrets Manager based secret plugin
+func (p *AWSServiceFactory) NewSecretService() (secret.SecretService, error) {
+	return secrets_manager_secret_service.New()
 }
 
 // NewStorageService - Returns AWS S3 based storage plugin

--- a/pkg/providers/azure/plugin.go
+++ b/pkg/providers/azure/plugin.go
@@ -17,10 +17,12 @@ package main
 import (
 	"github.com/nitric-dev/membrane/pkg/plugins/document"
 	mongodb_service "github.com/nitric-dev/membrane/pkg/plugins/document/mongodb"
+	"github.com/nitric-dev/membrane/pkg/plugins/emails"
 	"github.com/nitric-dev/membrane/pkg/plugins/events"
 	"github.com/nitric-dev/membrane/pkg/plugins/gateway"
 	http_service "github.com/nitric-dev/membrane/pkg/plugins/gateway/appservice"
 	"github.com/nitric-dev/membrane/pkg/plugins/queue"
+	"github.com/nitric-dev/membrane/pkg/plugins/secret"
 	"github.com/nitric-dev/membrane/pkg/plugins/storage"
 	"github.com/nitric-dev/membrane/pkg/providers"
 )
@@ -37,6 +39,11 @@ func (p *AzureServiceFactory) NewDocumentService() (document.DocumentService, er
 	return mongodb_service.New()
 }
 
+// NewEventService - Returns Azure _ based emails plugin
+func (p *AzureServiceFactory) NewEmailService() (emails.EmailService, error) {
+	return &emails.UnimplementedEmailService{}, nil
+}
+
 // NewEventService - Returns Azure _ based events plugin
 func (p *AzureServiceFactory) NewEventService() (events.EventService, error) {
 	return &events.UnimplementedeventsPlugin{}, nil
@@ -50,6 +57,11 @@ func (p *AzureServiceFactory) NewGatewayService() (gateway.GatewayService, error
 // NewQueueService - Returns Azure _ based queue plugin
 func (p *AzureServiceFactory) NewQueueService() (queue.QueueService, error) {
 	return &queue.UnimplementedQueuePlugin{}, nil
+}
+
+// NewSecretService - Returns Azure _ based secret plugin
+func (p *AzureServiceFactory) NewSecretService() (secret.SecretService, error) {
+	return &secret.UnimplementedSecretPlugin{}, nil
 }
 
 // NewStorageService - Returns Azure _ based storage plugin

--- a/pkg/providers/dev/membrane.go
+++ b/pkg/providers/dev/membrane.go
@@ -23,11 +23,12 @@ import (
 
 	"github.com/nitric-dev/membrane/pkg/membrane"
 	boltdb_service "github.com/nitric-dev/membrane/pkg/plugins/document/boltdb"
+	email_service "github.com/nitric-dev/membrane/pkg/plugins/emails/dev"
 	events_service "github.com/nitric-dev/membrane/pkg/plugins/events/dev"
 	gateway_plugin "github.com/nitric-dev/membrane/pkg/plugins/gateway/dev"
 	queue_service "github.com/nitric-dev/membrane/pkg/plugins/queue/dev"
-	boltdb_storage_service "github.com/nitric-dev/membrane/pkg/plugins/storage/boltdb"
 	secret_service "github.com/nitric-dev/membrane/pkg/plugins/secret/dev"
+	boltdb_storage_service "github.com/nitric-dev/membrane/pkg/plugins/storage/boltdb"
 )
 
 func main() {
@@ -38,6 +39,7 @@ func main() {
 
 	secretPlugin, _ := secret_service.New()
 	documentPlugin, _ := boltdb_service.New()
+	emailPlugin, _ := email_service.New()
 	eventsPlugin, _ := events_service.New()
 	gatewayPlugin, _ := gateway_plugin.New()
 	queuePlugin, _ := queue_service.New()
@@ -45,6 +47,7 @@ func main() {
 
 	m, err := membrane.New(&membrane.MembraneOptions{
 		DocumentPlugin: documentPlugin,
+		EmailsPlugin:   emailPlugin,
 		EventsPlugin:   eventsPlugin,
 		GatewayPlugin:  gatewayPlugin,
 		QueuePlugin:    queuePlugin,

--- a/pkg/providers/dev/plugin.go
+++ b/pkg/providers/dev/plugin.go
@@ -17,12 +17,16 @@ package main
 import (
 	"github.com/nitric-dev/membrane/pkg/plugins/document"
 	boltdb_service "github.com/nitric-dev/membrane/pkg/plugins/document/boltdb"
+	"github.com/nitric-dev/membrane/pkg/plugins/emails"
+	email_service "github.com/nitric-dev/membrane/pkg/plugins/emails/dev"
 	"github.com/nitric-dev/membrane/pkg/plugins/events"
 	events_service "github.com/nitric-dev/membrane/pkg/plugins/events/dev"
 	"github.com/nitric-dev/membrane/pkg/plugins/gateway"
 	gateway_plugin "github.com/nitric-dev/membrane/pkg/plugins/gateway/dev"
 	"github.com/nitric-dev/membrane/pkg/plugins/queue"
 	queue_service "github.com/nitric-dev/membrane/pkg/plugins/queue/dev"
+	"github.com/nitric-dev/membrane/pkg/plugins/secret"
+	secret_service "github.com/nitric-dev/membrane/pkg/plugins/secret/dev"
 	"github.com/nitric-dev/membrane/pkg/plugins/storage"
 	boltdb_storage_service "github.com/nitric-dev/membrane/pkg/plugins/storage/boltdb"
 	"github.com/nitric-dev/membrane/pkg/providers"
@@ -40,12 +44,17 @@ func (p *DevServiceFactory) NewDocumentService() (document.DocumentService, erro
 	return boltdb_service.New()
 }
 
+// NewEmailService - Returns local dev emails plugin
+func (p *DevServiceFactory) NewEmailService() (emails.EmailService, error) {
+	return email_service.New()
+}
+
 // NewEventService - Returns local dev events plugin
 func (p *DevServiceFactory) NewEventService() (events.EventService, error) {
 	return events_service.New()
 }
 
-// NewGatewayService - Returns local dev Gateway plugin
+// NewGatewayService - Returns local dev gateway plugin
 func (p *DevServiceFactory) NewGatewayService() (gateway.GatewayService, error) {
 	return gateway_plugin.New()
 }
@@ -53,6 +62,11 @@ func (p *DevServiceFactory) NewGatewayService() (gateway.GatewayService, error) 
 // NewQueueService - Returns local dev queue plugin
 func (p *DevServiceFactory) NewQueueService() (queue.QueueService, error) {
 	return queue_service.New()
+}
+
+// NewSecretService - Returns local dev secret plugin
+func (p *DevServiceFactory) NewSecretService() (secret.SecretService, error) {
+	return secret_service.New()
 }
 
 // NewStorageService - Returns local dev storage plugin

--- a/pkg/providers/gcp/plugin.go
+++ b/pkg/providers/gcp/plugin.go
@@ -17,12 +17,15 @@ package main
 import (
 	"github.com/nitric-dev/membrane/pkg/plugins/document"
 	firestore_service "github.com/nitric-dev/membrane/pkg/plugins/document/firestore"
+	"github.com/nitric-dev/membrane/pkg/plugins/emails"
 	"github.com/nitric-dev/membrane/pkg/plugins/events"
 	pubsub_service "github.com/nitric-dev/membrane/pkg/plugins/events/pubsub"
 	"github.com/nitric-dev/membrane/pkg/plugins/gateway"
 	cloudrun_plugin "github.com/nitric-dev/membrane/pkg/plugins/gateway/cloudrun"
 	"github.com/nitric-dev/membrane/pkg/plugins/queue"
 	pubsub_queue_service "github.com/nitric-dev/membrane/pkg/plugins/queue/pubsub"
+	"github.com/nitric-dev/membrane/pkg/plugins/secret"
+	secret_service "github.com/nitric-dev/membrane/pkg/plugins/secret/dev"
 	"github.com/nitric-dev/membrane/pkg/plugins/storage"
 	storage_service "github.com/nitric-dev/membrane/pkg/plugins/storage/storage"
 	"github.com/nitric-dev/membrane/pkg/providers"
@@ -40,6 +43,11 @@ func (p *GCPServiceFactory) NewDocumentService() (document.DocumentService, erro
 	return firestore_service.New()
 }
 
+// NewEventService - Returns Google Cloud _ based email service
+func (p *GCPServiceFactory) NewEmailService() (emails.EmailService, error) {
+	return &emails.UnimplementedEmailService{}, nil
+}
+
 // NewEventService - Returns Google Cloud Pubsub based events service
 func (p *GCPServiceFactory) NewEventService() (events.EventService, error) {
 	return pubsub_service.New()
@@ -53,6 +61,11 @@ func (p *GCPServiceFactory) NewGatewayService() (gateway.GatewayService, error) 
 // NewQueueService - Returns Google Cloud Pubsub based queue service
 func (p *GCPServiceFactory) NewQueueService() (queue.QueueService, error) {
 	return pubsub_queue_service.New()
+}
+
+// NewStorageService - Returns Google Cloud Storage based secret service
+func (p *GCPServiceFactory) NewSecretService() (secret.SecretService, error) {
+	return secret_service.New()
 }
 
 // NewStorageService - Returns Google Cloud Storage based storage service

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -16,18 +16,22 @@ package providers
 
 import (
 	"github.com/nitric-dev/membrane/pkg/plugins/document"
+	"github.com/nitric-dev/membrane/pkg/plugins/emails"
 	"github.com/nitric-dev/membrane/pkg/plugins/events"
 	"github.com/nitric-dev/membrane/pkg/plugins/gateway"
 	"github.com/nitric-dev/membrane/pkg/plugins/queue"
+	"github.com/nitric-dev/membrane/pkg/plugins/secret"
 	"github.com/nitric-dev/membrane/pkg/plugins/storage"
 )
 
 // ServiceFactory - interface for Service Factory Plugins, which instantiate provider specific service implementations.
 type ServiceFactory interface {
 	NewDocumentService() (document.DocumentService, error)
+	NewEmailService() (emails.EmailService, error)
 	NewEventService() (events.EventService, error)
 	NewGatewayService() (gateway.GatewayService, error)
 	NewQueueService() (queue.QueueService, error)
+	NewSecretService() (secret.SecretService, error)
 	NewStorageService() (storage.StorageService, error)
 }
 
@@ -49,6 +53,11 @@ func (p *UnimplementedServiceFactory) NewDocumentService() (document.DocumentSer
 	return nil, nil
 }
 
+// NewEmailService - Unimplemented
+func (p *UnimplementedServiceFactory) NewEmailService() (emails.EmailService, error) {
+	return nil, nil
+}
+
 // NewEventService - Unimplemented
 func (p *UnimplementedServiceFactory) NewEventService() (events.EventService, error) {
 	return nil, nil
@@ -61,6 +70,11 @@ func (p *UnimplementedServiceFactory) NewGatewayService() (gateway.GatewayServic
 
 // NewQueueService - Unimplemented
 func (p *UnimplementedServiceFactory) NewQueueService() (queue.QueueService, error) {
+	return nil, nil
+}
+
+// NewSecretService - Unimplemented
+func (p *UnimplementedServiceFactory) NewSecretService() (secret.SecretService, error) {
 	return nil, nil
 }
 

--- a/pluggable_membrane.go
+++ b/pluggable_membrane.go
@@ -24,9 +24,11 @@ import (
 
 	"github.com/nitric-dev/membrane/pkg/membrane"
 	"github.com/nitric-dev/membrane/pkg/plugins/document"
+	"github.com/nitric-dev/membrane/pkg/plugins/emails"
 	"github.com/nitric-dev/membrane/pkg/plugins/events"
 	"github.com/nitric-dev/membrane/pkg/plugins/gateway"
 	"github.com/nitric-dev/membrane/pkg/plugins/queue"
+	"github.com/nitric-dev/membrane/pkg/plugins/secret"
 	"github.com/nitric-dev/membrane/pkg/plugins/storage"
 	"github.com/nitric-dev/membrane/pkg/providers"
 	"github.com/nitric-dev/membrane/pkg/utils"
@@ -76,13 +78,19 @@ func main() {
 
 	// Load the concrete service implementations
 	var documentService document.DocumentService = nil
+	var emailService emails.EmailService = nil
 	var eventService events.EventService = nil
 	var gatewayService gateway.GatewayService = nil
 	var queueService queue.QueueService = nil
+	var secretService secret.SecretService = nil
 	var storageService storage.StorageService = nil
 
 	// Load the document service
 	if documentService, err = serviceFactory.NewDocumentService(); err != nil {
+		log.Fatal(err)
+	}
+	// Load the email service
+	if emailService, err = serviceFactory.NewEmailService(); err != nil {
 		log.Fatal(err)
 	}
 	// Load the eventing service
@@ -97,6 +105,10 @@ func main() {
 	if queueService, err = serviceFactory.NewQueueService(); err != nil {
 		log.Fatal(err)
 	}
+	// Load the secret service
+	if secretService, err = serviceFactory.NewSecretService(); err != nil {
+		log.Fatal(err)
+	}
 	// Load the storage service
 	if storageService, err = serviceFactory.NewStorageService(); err != nil {
 		log.Fatal(err)
@@ -108,10 +120,12 @@ func main() {
 		ChildAddress:            childAddress,
 		ChildCommand:            childCommand,
 		DocumentPlugin:          documentService,
+		EmailsPlugin:            emailService,
 		EventsPlugin:            eventService,
-		StoragePlugin:           storageService,
 		GatewayPlugin:           gatewayService,
 		QueuePlugin:             queueService,
+		SecretPlugin:            secretService,
+		StoragePlugin:           storageService,
 		TolerateMissingServices: tolerateMissing,
 	})
 


### PR DESCRIPTION
One thing to note - we discovered that the mail API from Google Cloud is deprecated, they recommend using 3rd party services like SendGrid, Mailgun or Mailjet. Perhaps we should drop this feature using a similar recommendation. Alternatively, we can find a good method for devs to select the email service plugin they want at build time, then integrate with those 3rd parties for them with our emails service.