### PR TITLE
Preserve API name as part of route worker and make it readable.

### DIFF
--- a/pkg/adapters/grpc/faas_grpc.go
+++ b/pkg/adapters/grpc/faas_grpc.go
@@ -52,6 +52,7 @@ func (s *FaasServer) TriggerStream(stream pb.FaasService_TriggerStreamServer) er
 	if api := ir.GetApi(); api != nil {
 		// Create a new route worker
 		wrkr = worker.NewRouteWorker(stream, &worker.RouteWorkerOptions{
+			Api:     api.Api,
 			Path:    api.Path,
 			Methods: api.Methods,
 		})

--- a/pkg/worker/route_worker.go
+++ b/pkg/worker/route_worker.go
@@ -25,10 +25,17 @@ import (
 
 // RouteWorker - Worker representation for an http api route handler
 type RouteWorker struct {
+	api     string
 	methods []string
 	path    string
 
 	GrpcWorker
+}
+
+// Api - Retrieve the name of the API this
+// route worker was registered for
+func (s *RouteWorker) Api() string {
+	return s.api
 }
 
 func (s *RouteWorker) extractPathParams(trigger *triggers.HttpRequest) (map[string]string, error) {
@@ -93,6 +100,7 @@ func (s *RouteWorker) HandleEvent(trigger *triggers.Event) error {
 }
 
 type RouteWorkerOptions struct {
+	Api     string
 	Path    string
 	Methods []string
 }
@@ -101,6 +109,7 @@ type RouteWorkerOptions struct {
 // Only a pool may create a new faas worker
 func NewRouteWorker(stream pb.FaasService_TriggerStreamServer, opts *RouteWorkerOptions) *RouteWorker {
 	return &RouteWorker{
+		api:        opts.Api,
 		path:       opts.Path,
 		methods:    opts.Methods,
 		GrpcWorker: NewGrpcListener(stream),


### PR DESCRIPTION
Preserving API name metadata for route workers. This will allow us to do named API sub routing in single membrane gateway scenarios e.g. nitric run.