### PR TITLE
feat: allow getting all matching workers from pool

### DIFF
--- a/pkg/worker/pool.go
+++ b/pkg/worker/pool.go
@@ -170,10 +170,6 @@ func (p *ProcessPool) GetWorkers(opts *GetWorkerOptions) []Worker {
 	if opts.Http != nil {
 		ws := p.getHttpWorkers()
 
-		if opts.Filter != nil {
-			ws = filterWorkers(ws, opts.Filter)
-		}
-
 		for _, w := range ws {
 			if w.HandlesHttpRequest(opts.Http) {
 				workers = append(workers, w)
@@ -184,15 +180,15 @@ func (p *ProcessPool) GetWorkers(opts *GetWorkerOptions) []Worker {
 	if opts.Event != nil {
 		ws := p.getEventWorkers()
 
-		if opts.Filter != nil {
-			ws = filterWorkers(ws, opts.Filter)
-		}
-
 		for _, w := range ws {
 			if w.HandlesEvent(opts.Event) {
 				workers = append(workers, w)
 			}
 		}
+	}
+
+	if opts.Filter != nil {
+		workers = filterWorkers(workers, opts.Filter)
 	}
 
 	return workers

--- a/pkg/worker/pool.go
+++ b/pkg/worker/pool.go
@@ -27,6 +27,7 @@ type WorkerPool interface {
 	WaitForMinimumWorkers(timeout int) error
 	GetWorkerCount() int
 	GetWorker(*GetWorkerOptions) (Worker, error)
+	GetWorkers(*GetWorkerOptions) []Worker
 	AddWorker(Worker) error
 	RemoveWorker(Worker) error
 	Monitor() error
@@ -156,6 +157,45 @@ func filterWorkers(ws []Worker, f func(w Worker) bool) []Worker {
 	}
 
 	return newWs
+}
+
+// GetWorkers - return a slice of all workers matching the input options.
+// useful for retrieving a list of all topic subscribers (for example)
+func (p *ProcessPool) GetWorkers(opts *GetWorkerOptions) []Worker {
+	p.workerLock.Lock()
+	defer p.workerLock.Unlock()
+
+	workers := make([]Worker, 0)
+
+	if opts.Http != nil {
+		ws := p.getHttpWorkers()
+
+		if opts.Filter != nil {
+			ws = filterWorkers(ws, opts.Filter)
+		}
+
+		for _, w := range ws {
+			if w.HandlesHttpRequest(opts.Http) {
+				workers = append(workers, w)
+			}
+		}
+	}
+
+	if opts.Event != nil {
+		ws := p.getEventWorkers()
+
+		if opts.Filter != nil {
+			ws = filterWorkers(ws, opts.Filter)
+		}
+
+		for _, w := range ws {
+			if w.HandlesEvent(opts.Event) {
+				workers = append(workers, w)
+			}
+		}
+	}
+
+	return workers
 }
 
 // GetWorker - Retrieves a worker from this pool


### PR DESCRIPTION
This lets us get all workers when running locally and retrieving all subscribers for an event.