### PR TITLE
feat: update event message to match CloudEvents spec

### DIFF
--- a/contracts/proto/event/v1/event.proto
+++ b/contracts/proto/event/v1/event.proto
@@ -63,7 +63,11 @@ message NitricEvent {
   // A Unique ID for the Nitric Event
   string id = 1;
   // A content hint for the events payload
-  string payload_type = 2;
+  string type = 2;
   // The payload of the event
-  google.protobuf.Struct payload = 3;
+  oneof data {
+    bytes binary_data = 4;
+    string text_data = 5;
+    google.protobuf.Struct proto_data = 3;
+  }
 }


### PR DESCRIPTION
Not fully compatible with cloud events yet, but closer. This shouldn't be a breaking change.