### PR TITLE
Externalise default child process default into provider entrypoints

### DIFF
--- a/pkg/membrane/defaults.go
+++ b/pkg/membrane/defaults.go
@@ -1,0 +1,24 @@
+package membrane
+
+import (
+	"log"
+	"os"
+	"strings"
+
+	"github.com/nitrictech/nitric/pkg/utils"
+)
+
+func DefaultMembraneOptions() *MembraneOptions {
+	options := &MembraneOptions{}
+
+	if len(os.Args) > 1 && len(os.Args[1:]) > 0 {
+		options.ChildCommand = os.Args[1:]
+	} else {
+		options.ChildCommand = strings.Fields(utils.GetEnv("INVOKE", ""))
+		if len(options.ChildCommand) > 0 {
+			log.Default().Println("Warning: use of INVOKE environment variable is deprecated and may be removed in a future version")
+		}
+	}
+
+	return options
+}

--- a/pkg/membrane/defaults.go
+++ b/pkg/membrane/defaults.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Nitric Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package membrane
 
 import (

--- a/pkg/membrane/membrane.go
+++ b/pkg/membrane/membrane.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
-	"strings"
 
 	"google.golang.org/grpc"
 
@@ -290,19 +289,6 @@ func New(options *MembraneOptions) (*Membrane, error) {
 
 	if options.ChildAddress == "" {
 		options.ChildAddress = utils.GetEnv("CHILD_ADDRESS", "127.0.0.1:8080")
-	}
-
-	// Pull child command from command line args or environment variable if not provided.
-	if len(options.ChildCommand) < 1 {
-		// Get the command line arguments, minus the program name in index 0.
-		if len(os.Args) > 1 && len(os.Args[1:]) > 0 {
-			options.ChildCommand = os.Args[1:]
-		} else {
-			options.ChildCommand = strings.Fields(utils.GetEnv("INVOKE", ""))
-			if len(options.ChildCommand) > 0 {
-				log.Default().Println("Warning: use of INVOKE environment variable is deprecated and may be removed in a future version")
-			}
-		}
 	}
 
 	if !options.TolerateMissingServices {

--- a/pkg/providers/azure/membrane.go
+++ b/pkg/providers/azure/membrane.go
@@ -32,35 +32,31 @@ import (
 )
 
 func main() {
+	var err error
 	term := make(chan os.Signal, 1)
 	signal.Notify(term, os.Interrupt, syscall.SIGTERM)
 	signal.Notify(term, os.Interrupt, syscall.SIGINT)
 
-	documentPlugin, err := mongodb_service.New()
+	membraneOpts := membrane.DefaultMembraneOptions()
+
+	membraneOpts.DocumentPlugin, err = mongodb_service.New()
 	if err != nil {
 		log.Default().Println("Failed to load document plugin:", err.Error())
 	}
 
-	eventsPlugin, err := event_grid.New()
+	membraneOpts.EventsPlugin, err = event_grid.New()
 	if err != nil {
 		log.Default().Println("Failed to load event plugin:", err.Error())
 	}
-	gatewayPlugin, _ := http_service.New()
-	queuePlugin, _ := azqueue_service.New()
-	storagePlugin, _ := azblob_service.New()
-	secretPlugin, err := key_vault.New()
+	membraneOpts.GatewayPlugin, _ = http_service.New()
+	membraneOpts.QueuePlugin, _ = azqueue_service.New()
+	membraneOpts.StoragePlugin, _ = azblob_service.New()
+	membraneOpts.SecretPlugin, err = key_vault.New()
 	if err != nil {
 		log.Default().Println("Failed to load secret plugin:", err.Error())
 	}
 
-	m, err := membrane.New(&membrane.MembraneOptions{
-		DocumentPlugin: documentPlugin,
-		EventsPlugin:   eventsPlugin,
-		GatewayPlugin:  gatewayPlugin,
-		QueuePlugin:    queuePlugin,
-		StoragePlugin:  storagePlugin,
-		SecretPlugin:   secretPlugin,
-	})
+	m, err := membrane.New(membraneOpts)
 
 	if err != nil {
 		log.Fatalf("There was an error initialising the membrane server: %v", err)

--- a/pkg/providers/dev/membrane.go
+++ b/pkg/providers/dev/membrane.go
@@ -36,21 +36,16 @@ func main() {
 	signal.Notify(term, os.Interrupt, syscall.SIGTERM)
 	signal.Notify(term, os.Interrupt, syscall.SIGINT)
 
-	secretPlugin, _ := secret_service.New()
-	documentPlugin, _ := boltdb_service.New()
-	eventsPlugin, _ := events_service.New()
-	gatewayPlugin, _ := gateway_plugin.New()
-	queuePlugin, _ := queue_service.New()
-	storagePlugin, _ := minio_storage_service.New()
+	membraneOpts := membrane.DefaultMembraneOptions()
 
-	m, err := membrane.New(&membrane.MembraneOptions{
-		DocumentPlugin: documentPlugin,
-		EventsPlugin:   eventsPlugin,
-		GatewayPlugin:  gatewayPlugin,
-		QueuePlugin:    queuePlugin,
-		StoragePlugin:  storagePlugin,
-		SecretPlugin:   secretPlugin,
-	})
+	membraneOpts.SecretPlugin, _ = secret_service.New()
+	membraneOpts.DocumentPlugin, _ = boltdb_service.New()
+	membraneOpts.EventsPlugin, _ = events_service.New()
+	membraneOpts.GatewayPlugin, _ = gateway_plugin.New()
+	membraneOpts.QueuePlugin, _ = queue_service.New()
+	membraneOpts.StoragePlugin, _ = minio_storage_service.New()
+
+	m, err := membrane.New(membraneOpts)
 
 	if err != nil {
 		log.Fatalf("There was an error initialising the membraneServer server: %v", err)

--- a/pkg/providers/do/membrane.go
+++ b/pkg/providers/do/membrane.go
@@ -30,13 +30,12 @@ func main() {
 	signal.Notify(term, os.Interrupt, syscall.SIGTERM)
 	signal.Notify(term, os.Interrupt, syscall.SIGINT)
 
-	gatewayPlugin, _ := appplatform_service.New()
+	membraneOpts := membrane.DefaultMembraneOptions()
 
-	m, err := membrane.New(&membrane.MembraneOptions{
-		GatewayPlugin: gatewayPlugin,
-		// FIXME: Hardcode as true as we don't have plugins for other services for digital ocean yet...
-		TolerateMissingServices: true,
-	})
+	membraneOpts.GatewayPlugin, _ = appplatform_service.New()
+	membraneOpts.TolerateMissingServices = true
+
+	m, err := membrane.New(membraneOpts)
 
 	if err != nil {
 		log.Fatalf("There was an error initialising the membrane server: %v", err)

--- a/pkg/providers/gcp/membrane.go
+++ b/pkg/providers/gcp/membrane.go
@@ -32,44 +32,44 @@ import (
 
 func main() {
 	// Setup signal interrupt handling for graceful shutdown
+	var err error
 	term := make(chan os.Signal, 1)
 	signal.Notify(term, os.Interrupt, syscall.SIGTERM)
 	signal.Notify(term, os.Interrupt, syscall.SIGINT)
 
-	secretPlugin, err := secret_manager_secret_service.New()
+	membraneOpts := membrane.DefaultMembraneOptions()
+
+	membraneOpts.SecretPlugin, err = secret_manager_secret_service.New()
 	if err != nil {
 		log.Default().Println("Failed to load secret plugin:", err.Error())
 	}
 
-	documentPlugin, err := firestore_service.New()
+	membraneOpts.DocumentPlugin, err = firestore_service.New()
 	if err != nil {
 		log.Default().Println("Failed to load document plugin:", err.Error())
 	}
-	eventsPlugin, err := pubsub_service.New()
+
+	membraneOpts.EventsPlugin, err = pubsub_service.New()
 	if err != nil {
 		log.Default().Println("Failed to load events plugin:", err.Error())
 	}
-	storagePlugin, err := storage_service.New()
+
+	membraneOpts.StoragePlugin, err = storage_service.New()
 	if err != nil {
 		log.Default().Println("Failed to load storage plugin:", err.Error())
 	}
-	gatewayPlugin, err := cloudrun_plugin.New()
+
+	membraneOpts.GatewayPlugin, err = cloudrun_plugin.New()
 	if err != nil {
 		log.Default().Println("Failed to load gateway plugin:", err.Error())
 	}
-	queuePlugin, err := pubsub_queue_service.New()
+
+	membraneOpts.QueuePlugin, err = pubsub_queue_service.New()
 	if err != nil {
 		log.Default().Println("Failed to load queue plugin:", err.Error())
 	}
 
-	m, err := membrane.New(&membrane.MembraneOptions{
-		DocumentPlugin: documentPlugin,
-		EventsPlugin:   eventsPlugin,
-		GatewayPlugin:  gatewayPlugin,
-		QueuePlugin:    queuePlugin,
-		StoragePlugin:  storagePlugin,
-		SecretPlugin:   secretPlugin,
-	})
+	m, err := membrane.New(membraneOpts)
 
 	if err != nil {
 		log.Fatalf("There was an error initialising the membrane server: %v", err)


### PR DESCRIPTION
Enable starting embedded membrane in cli without a child process