### PR TITLE
Shorten and simplify worker polling

### DIFF
--- a/pkg/worker/pool.go
+++ b/pkg/worker/pool.go
@@ -121,21 +121,22 @@ func (p *ProcessPool) Monitor() error {
 
 // WaitForMinimumWorkers - Waits for the configured minimum number of workers to be available in this pool
 func (p *ProcessPool) WaitForMinimumWorkers(timeout int) error {
-	maxWaitTime := time.Duration(timeout) * time.Second
-	// Longer poll times, e.g. 200 milliseconds results in slow lambda cold starts (15s+)
-	pollInterval := time.Duration(15) * time.Millisecond
+	waitUntil := time.Now().Add(time.Duration(timeout) * time.Second)
+	ticker := time.NewTicker(time.Duration(5) * time.Millisecond)
 
-	var waitedTime = time.Duration(0)
+	// stop the ticker on exit
+	defer ticker.Stop()
+
 	for {
 		if p.GetWorkerCount() >= p.minWorkers {
 			break
-		} else {
-			if waitedTime < maxWaitTime {
-				time.Sleep(pollInterval)
-				waitedTime += pollInterval
-			} else {
-				return fmt.Errorf("available workers below required minimum of %d, %d available, timedout waiting for more workers", p.minWorkers, p.GetWorkerCount())
-			}
+		}
+
+		// wait for the next tick
+		time := <-ticker.C
+
+		if time.After(waitUntil) {
+			return fmt.Errorf("available workers below required minimum of %d, %d available, timed out waiting for more workers", p.minWorkers, p.GetWorkerCount())
 		}
 	}
 


### PR DESCRIPTION
shortening polling time to prevent throttling on serverless runtimes like AWS lambda during cold starts.