### PR TITLE
fix: remove debug output for local events

### DIFF
--- a/pkg/plugins/events/dev/eventing.go
+++ b/pkg/plugins/events/dev/eventing.go
@@ -67,7 +67,6 @@ func (s *LocalEventService) Publish(topic string, event *events.NitricEvent) err
 	}
 
 	if targets, ok := s.subscriptions[topic]; ok {
-		log.Default().Println(fmt.Sprintf("Publishing event to: %s", targets))
 		for _, target := range targets {
 			httpRequest, _ := http.NewRequest("POST", target, bytes.NewReader(marshaledPayload))
 


### PR DESCRIPTION
This line wasn't printing nicely during a local run. If we add this back in, it should be more intentional and useful for developers.