### PR TITLE
feat: change subcollection delimiter

### DIFF
--- a/pkg/plugins/document/boltdb/boltdb.go
+++ b/pkg/plugins/document/boltdb/boltdb.go
@@ -35,11 +35,12 @@ import (
 )
 
 const DEV_SUB_DIRECTORY = "./collections/"
-
-const skipTokenName = "skip"
-const idName = "Id"
-const partitionKeyName = "PartitionKey"
-const sortKeyName = "SortKey"
+const (
+	skipTokenName    = "skip"
+	idName           = "Id"
+	partitionKeyName = "PartitionKey"
+	sortKeyName      = "SortKey"
+)
 
 type BoltDocService struct {
 	document.UnimplementedDocumentPlugin
@@ -465,7 +466,7 @@ func createDoc(key *document.Key) BoltDoc {
 		}
 	} else {
 		return BoltDoc{
-			Id:           parentKey.Id + "_" + key.Id,
+			Id:           parentKey.Id + document.SubcollectionDelimiter + key.Id,
 			PartitionKey: parentKey.Id,
 			SortKey:      key.Collection.Name + "#" + key.Id,
 		}
@@ -473,7 +474,7 @@ func createDoc(key *document.Key) BoltDoc {
 }
 
 func toSdkDoc(col *document.Collection, doc BoltDoc) *document.Document {
-	keys := strings.Split(doc.Id, "_")
+	keys := strings.Split(doc.Id, document.SubcollectionDelimiter)
 
 	// Translate the boltdb Id into a nitric document key Id
 	var id string

--- a/pkg/plugins/document/document.go
+++ b/pkg/plugins/document/document.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 )
 
+const SubcollectionDelimiter = "+"
+
 // Map of valid expression operators
 var validOperators = map[string]bool{
 	"==":         true,
@@ -37,6 +39,9 @@ func ValidateKey(key *Key) error {
 	}
 	if key.Id == "" {
 		return fmt.Errorf("provide non-blank key.Id")
+	}
+	if strings.Contains(key.Id, SubcollectionDelimiter) {
+		return fmt.Errorf("key.Id cannot contain %s", SubcollectionDelimiter)
 	}
 	if key.Collection == nil {
 		return fmt.Errorf("provide non-nil key.Collection")


### PR DESCRIPTION
# Change subcollection delimiter

# Description

Changed the subcollection delimiter to be + instead of _ as this is much less common as an id format than _.

Fixes #249 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Confirmed that the bug occurred with the same tests for the unaltered membrane.
Then to confirm the change fixed this bug, used [BloomRPC](https://github.com/bloomrpc/bloomrpc) with the local membrane to do tests for getting, setting, and deleting documents. Then tested with a local nitric run by pointing the CLI membrane plugins to my local membrane plugins and performing get, set, and delete against the collection. 
