### PR TITLE
ci: fix binary releases.

### DIFF
--- a/.github/workflows/publish-binaries.yaml
+++ b/.github/workflows/publish-binaries.yaml
@@ -33,7 +33,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.NITRIC_BOT_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./provider/aws/bin/runtime-aws
+          asset_path: ./cloud/aws/bin/runtime-aws
           asset_name: membrane-aws
           asset_content_type: application/octet-stream
       - name: Upload GCP
@@ -42,7 +42,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.NITRIC_BOT_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./provider/gcp/bin/runtime-gcp
+          asset_path: ./cloud/gcp/bin/runtime-gcp
           asset_name: membrane-gcp
           asset_content_type: application/octet-stream
       - name: Upload Azure
@@ -51,6 +51,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.NITRIC_BOT_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./provider/azure/bin/runtime-azure
+          asset_path: ./cloud/azure/bin/runtime-azure
           asset_name: membrane-azure
           asset_content_type: application/octet-stream


### PR DESCRIPTION
forgot to update the binary release actions with the provider->cloud rename.