### PR TITLE
Feat/set max concurrent streams

### DIFF
--- a/core/pkg/worker/pool.go
+++ b/core/pkg/worker/pool.go
@@ -31,6 +31,8 @@ type WorkerPool interface {
 	AddWorker(Worker) error
 	RemoveWorker(Worker) error
 	Monitor() error
+	GetMinWorkers() int
+	GetMaxWorkers() int
 }
 
 type ProcessPoolOptions struct {


### PR DESCRIPTION
<!---
Thanks for your contribution! Please ensure that you have read the [Contribution guide](https://github.com/nitrictech/nitric/blob/main/CONTRIBUTING.md).
-->

# Description

Adds the ability to set the max concurrent stream option from grpc. Also increases the max workers default value to 300.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
