### PR TITLE
feat: Azure config

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum', '**/work.sum') }}
         restore-keys: |
           ${{ runner.os }}-golang-
     - name: Linting check

--- a/cloud/aws/deploy/config/config.go
+++ b/cloud/aws/deploy/config/config.go
@@ -17,13 +17,10 @@
 package config
 
 import (
-	"github.com/imdario/mergo"
-	"github.com/mitchellh/mapstructure"
+	"github.com/nitrictech/nitric/cloud/common/deploy/config"
 )
 
-type AwsConfig struct {
-	Config map[string]AwsConfigItem
-}
+type AwsConfig = config.AbstractConfig[AwsConfigItem]
 
 type AwsConfigItem struct {
 	Lambda    AwsLambdaConfig
@@ -37,48 +34,18 @@ type AwsLambdaConfig struct {
 	ProvisionedConcurreny int `mapstructure:"provisioned-concurrency"`
 }
 
-var defaultAwsConfig = &AwsConfig{
-	Config: map[string]AwsConfigItem{
-		"default": {
-			Lambda: AwsLambdaConfig{
-				Memory:                128,
-				Timeout:               15,
-				ProvisionedConcurreny: 0,
-			},
-			Telemetry: 0,
-			Target:    "lambda",
-		},
+var defaultAwsConfigItem = AwsConfigItem{
+	Lambda: AwsLambdaConfig{
+		Memory:                128,
+		Timeout:               15,
+		ProvisionedConcurreny: 0,
 	},
+	Telemetry: 0,
+	Target:    "lambda",
 }
 
-// Return AwsConfig from stack attributes
-func ConfigFromAttributes(attributes map[string]interface{}) (AwsConfig, error) {
-	config := AwsConfig{}
-
-	err := mapstructure.Decode(attributes, &config)
-
-	// deep merge with defaults
-	if err := mergo.Merge(&config, defaultAwsConfig); err != nil {
-		return config, err
-	}
-
-	// capture default config and have other configs inherit it
-	defaultConfig := config.Config["default"]
-
-	// merge each no default key with defaults as well
-	for name, val := range config.Config {
-		if name == "default" {
-			continue
-		}
-
-		defaultVal := defaultConfig
-
-		if err := mergo.Merge(&defaultVal, &val, mergo.WithOverride); err != nil {
-			return config, err
-		}
-
-		config.Config[name] = defaultVal
-	}
-
-	return config, err
+// Return GcpConfig from stack attributes
+func ConfigFromAttributes(attributes map[string]interface{}) (*AwsConfig, error) {
+	// Use common ConfigFromAttributes
+	return config.ConfigFromAttributes(attributes, defaultAwsConfigItem)
 }

--- a/cloud/azure/deploy/config/config.go
+++ b/cloud/azure/deploy/config/config.go
@@ -21,7 +21,7 @@ import (
 )
 
 type AzureConfigItem struct {
-	ContainerApps AzureContainerAppsConfig
+	ContainerApps AzureContainerAppsConfig `mapstructure:"containerapps"`
 	Telemetry     int
 	Target        string
 }
@@ -37,7 +37,7 @@ type AzureConfig = config.AbstractConfig[AzureConfigItem]
 
 var defaultAzureConfigItem = AzureConfigItem{
 	ContainerApps: AzureContainerAppsConfig{
-		Cpu:         0.5,
+		Cpu:         0.25,
 		Memory:      0.5,
 		MinReplicas: 0,
 		MaxReplicas: 10,

--- a/cloud/azure/deploy/config/config.go
+++ b/cloud/azure/deploy/config/config.go
@@ -1,0 +1,53 @@
+// Copyright Nitric Pty Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"github.com/nitrictech/nitric/cloud/common/deploy/config"
+)
+
+type AzureConfigItem struct {
+	ContainerApps AzureContainerAppsConfig
+	Telemetry     int
+	Target        string
+}
+
+type AzureContainerAppsConfig struct {
+	Cpu         float64
+	Memory      float64
+	MinReplicas int `mapstructure:"min-replicas"`
+	MaxReplicas int `mapstructure:"max-replicas"`
+}
+
+type AzureConfig = config.AbstractConfig[AzureConfigItem]
+
+var defaultAzureConfigItem = AzureConfigItem{
+	ContainerApps: AzureContainerAppsConfig{
+		Cpu:         0.5,
+		Memory:      0.5,
+		MinReplicas: 0,
+		MaxReplicas: 10,
+	},
+	Telemetry: 0,
+	Target:    "containerapps",
+}
+
+// Return AzureConfig from stack attributes
+func ConfigFromAttributes(attributes map[string]interface{}) (*AzureConfig, error) {
+	// Use common ConfigFromAttributes
+	return config.ConfigFromAttributes(attributes, defaultAzureConfigItem)
+}

--- a/cloud/azure/deploy/exec/containerapp.go
+++ b/cloud/azure/deploy/exec/containerapp.go
@@ -264,7 +264,7 @@ func NewContainerApp(ctx *pulumi.Context, name string, args *ContainerAppArgs, o
 					Image: args.ImageUri,
 					Resources: app.ContainerResourcesArgs{
 						Cpu:    pulumi.Float64(args.Config.Cpu),
-						Memory: pulumi.Sprintf("%sGi", args.Config.Memory),
+						Memory: pulumi.Sprintf("%.2fGi", args.Config.Memory),
 					},
 					Env: env,
 				},

--- a/cloud/azure/deploy/up.go
+++ b/cloud/azure/deploy/up.go
@@ -221,7 +221,6 @@ func (d *DeployServer) Up(request *deploy.DeployUpRequest, stream deploy.DeployS
 			}
 
 			for _, eu := range executionUnits {
-
 				repositoryUrl := pulumi.Sprintf("%s/%s-%s-%s", contEnv.Registry.LoginServer, details.Project, eu.Name, "azure")
 
 				image, err := image.NewImage(ctx, eu.Name, &image.ImageArgs{

--- a/cloud/azure/deploy/up.go
+++ b/cloud/azure/deploy/up.go
@@ -36,6 +36,7 @@ import (
 	"github.com/nitrictech/nitric/cloud/azure/deploy/api"
 	"github.com/nitrictech/nitric/cloud/azure/deploy/bucket"
 	"github.com/nitrictech/nitric/cloud/azure/deploy/collection"
+	"github.com/nitrictech/nitric/cloud/azure/deploy/config"
 	"github.com/nitrictech/nitric/cloud/azure/deploy/exec"
 	"github.com/nitrictech/nitric/cloud/azure/deploy/queue"
 	"github.com/nitrictech/nitric/cloud/azure/deploy/topic"
@@ -49,6 +50,11 @@ import (
 // Up - Deploy requested infrastructure for a stack
 func (d *DeployServer) Up(request *deploy.DeployUpRequest, stream deploy.DeployService_UpServer) error {
 	details, err := getStackDetailsFromAttributes(request.Attributes.AsMap())
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, err.Error())
+	}
+
+	config, err := config.ConfigFromAttributes(request.Attributes.AsMap())
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, err.Error())
 	}
@@ -215,6 +221,7 @@ func (d *DeployServer) Up(request *deploy.DeployUpRequest, stream deploy.DeployS
 			}
 
 			for _, eu := range executionUnits {
+
 				repositoryUrl := pulumi.Sprintf("%s/%s-%s-%s", contEnv.Registry.LoginServer, details.Project, eu.Name, "azure")
 
 				image, err := image.NewImage(ctx, eu.Name, &image.ImageArgs{
@@ -236,23 +243,37 @@ func (d *DeployServer) Up(request *deploy.DeployUpRequest, stream deploy.DeployS
 					mongoConnectionString = mongoCollections.ConnectionString
 				}
 
-				apps[eu.Name], err = exec.NewContainerApp(ctx, eu.Name, &exec.ContainerAppArgs{
-					ResourceGroupName:             rg.Name,
-					Location:                      pulumi.String(details.Region),
-					SubscriptionID:                pulumi.String(clientConfig.SubscriptionId),
-					Registry:                      contEnv.Registry,
-					RegistryUser:                  contEnv.RegistryUser,
-					RegistryPass:                  contEnv.RegistryPass,
-					ManagedEnv:                    contEnv.ManagedEnv,
-					ImageUri:                      image.URI(),
-					Env:                           contEnv.Env,
-					ExecutionUnit:                 eu.GetExecutionUnit(),
-					ManagedIdentityID:             contEnv.ManagedUser.ClientId,
-					MongoDatabaseName:             mongodbName,
-					MongoDatabaseConnectionString: mongoConnectionString,
-				}, pulumi.Parent(contEnv))
-				if err != nil {
-					return err
+				if eu.GetExecutionUnit().Type == "" {
+					eu.GetExecutionUnit().Type = "default"
+				}
+
+				euConfig, hasConfig := config.Config[eu.GetExecutionUnit().Type]
+				if !hasConfig {
+					return status.Errorf(codes.InvalidArgument, "Could not find type %s in config %+v", eu.GetExecutionUnit().Type, config)
+				}
+
+				switch euConfig.Target {
+				case "containerapps":
+					apps[eu.Name], err = exec.NewContainerApp(ctx, eu.Name, &exec.ContainerAppArgs{
+						ResourceGroupName:             rg.Name,
+						Location:                      pulumi.String(details.Region),
+						SubscriptionID:                pulumi.String(clientConfig.SubscriptionId),
+						Registry:                      contEnv.Registry,
+						RegistryUser:                  contEnv.RegistryUser,
+						RegistryPass:                  contEnv.RegistryPass,
+						ManagedEnv:                    contEnv.ManagedEnv,
+						ImageUri:                      image.URI(),
+						ExecutionUnit:                 eu.GetExecutionUnit(),
+						ManagedIdentityID:             contEnv.ManagedUser.ClientId,
+						MongoDatabaseName:             mongodbName,
+						MongoDatabaseConnectionString: mongoConnectionString,
+						Config:                        euConfig.ContainerApps,
+					}, pulumi.Parent(contEnv))
+					if err != nil {
+						return err
+					}
+				default:
+					return status.Errorf(codes.InvalidArgument, "Invalid target %s for execution unit %s", euConfig.Target, eu.Name)
 				}
 			}
 		}

--- a/cloud/common/deploy/config/config.go
+++ b/cloud/common/deploy/config/config.go
@@ -1,0 +1,60 @@
+// Copyright Nitric Pty Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"github.com/imdario/mergo"
+	"github.com/mitchellh/mapstructure"
+)
+
+type AbstractItem = any
+
+type AbstractConfig[T AbstractItem] struct {
+	Config map[string]T
+}
+
+// ConfigFromAttributes - Merges given attributes into a useable config, all types are updated with the provided default config item
+func ConfigFromAttributes[T AbstractItem](attributes map[string]interface{}, defaultItem T) (*AbstractConfig[T], error) {
+	config := new(AbstractConfig[T])
+
+	err := mapstructure.Decode(attributes, config)
+
+	// deep merge default type
+	if err := mergo.Merge(config, &AbstractConfig[T]{Config: map[string]T{"default": defaultItem}}); err != nil {
+		return config, err
+	}
+
+	// capture default config and have other configs inherit it
+	defaultConfig := config.Config["default"]
+
+	// merge each no default key with defaults as well
+	for name, val := range config.Config {
+		if name == "default" {
+			continue
+		}
+
+		defaultVal := defaultConfig
+
+		if err := mergo.Merge(&defaultVal, &val, mergo.WithOverride); err != nil {
+			return config, err
+		}
+
+		config.Config[name] = defaultVal
+	}
+
+	return config, err
+}


### PR DESCRIPTION
Adds azure config, note `memory` config for azure container apps can only be done in gigabytes, so it will differ from the other cloud memory configs (want the config to be closer to the actual cloud rather than perform arbitrary conversions).