### PR TITLE
feat: add name resolution for GCP topics and queues

### DIFF
--- a/cloud/gcp/Makefile
+++ b/cloud/gcp/Makefile
@@ -30,12 +30,15 @@ sourcefiles := $(shell find . -type f -name "*.go" -o -name "*.dockerfile")
 
 fmt:
 	@go run github.com/google/addlicense -c "Nitric Technologies Pty Ltd." -y "2021" $(sourcefiles)
+	@touch deploy/runtime-gcp
 	$(GOLANGCI_LINT) run --fix
+	@rm deploy/runtime-gcp
 
 lint:
 	@touch deploy/runtime-gcp
 	@go run github.com/google/addlicense -check -c "Nitric Technologies Pty Ltd." -y "2021" $(sourcefiles)
 	$(GOLANGCI_LINT) run
+	@rm deploy/runtime-gcp
 
 license-check: runtimebin
 	@echo Checking GCP Membrane OSS Licenses

--- a/cloud/gcp/deploy/events/pubsub.go
+++ b/cloud/gcp/deploy/events/pubsub.go
@@ -17,7 +17,8 @@
 package events
 
 import (
-	"github.com/nitrictech/nitric/cloud/azure/deploy/utils"
+	"fmt"
+
 	common "github.com/nitrictech/nitric/cloud/common/deploy/tags"
 	"github.com/nitrictech/nitric/cloud/gcp/deploy/exec"
 	v1 "github.com/nitrictech/nitric/core/pkg/api/nitric/deploy/v1"
@@ -54,7 +55,6 @@ func NewPubSubTopic(ctx *pulumi.Context, name string, args *PubSubTopicArgs, opt
 	}
 
 	res.PubSub, err = pubsub.NewTopic(ctx, name, &pubsub.TopicArgs{
-		Name:   pulumi.String(name),
 		Labels: common.Tags(ctx, args.StackID, name),
 	})
 	if err != nil {
@@ -73,11 +73,16 @@ type PubSubSubscription struct {
 }
 
 type PubSubSubscriptionArgs struct {
-	Function *exec.CloudRunner
-	Topic    string
+	Function       *exec.CloudRunner
+	Topic          *PubSubTopic
+	InvokerAccount *serviceaccount.Account
 }
 
-func NewPubSubSubscription(ctx *pulumi.Context, name string, args *PubSubSubscriptionArgs, opts ...pulumi.ResourceOption) (*PubSubSubscription, error) {
+func GetSubName(executionName string, topicName string) string {
+	return fmt.Sprintf("%s-%s-sub", executionName, topicName)
+}
+
+func NewPubSubPushSubscription(ctx *pulumi.Context, name string, args *PubSubSubscriptionArgs, opts ...pulumi.ResourceOption) (*PubSubSubscription, error) {
 	res := &PubSubSubscription{
 		Name: name,
 	}
@@ -87,30 +92,18 @@ func NewPubSubSubscription(ctx *pulumi.Context, name string, args *PubSubSubscri
 		return nil, err
 	}
 
-	// Create an account for invoking this func via subscriptions
-	// TODO: Do we want to make this one account for subscription in future
-	// TODO: We will likely configure this via eventarc in the future
-	invokerAccount, err := serviceaccount.NewAccount(ctx, name+"subacct", &serviceaccount.AccountArgs{
-		// accountId accepts a max of 30 chars, limit our generated name to this length
-		AccountId: pulumi.String(utils.StringTrunc(name, 30-8) + "subacct"),
-	}, append(opts, pulumi.Parent(res))...)
-	if err != nil {
-		return nil, errors.WithMessage(err, "invokerAccount "+name)
-	}
-
-	// Apply permissions for the above account to the newly deployed cloud run service
 	_, err = cloudrun.NewIamMember(ctx, name+"-subrole", &cloudrun.IamMemberArgs{
-		Member:   pulumi.Sprintf("serviceAccount:%s", invokerAccount.Email),
+		Member:   pulumi.Sprintf("serviceAccount:%s", args.InvokerAccount.Email),
 		Role:     pulumi.String("roles/run.invoker"),
 		Service:  args.Function.Service.Name,
 		Location: args.Function.Service.Location,
 	}, append(opts, pulumi.Parent(res))...)
 	if err != nil {
-		return nil, errors.WithMessage(err, "iam member "+name)
+		return nil, errors.WithMessage(err, "subscription "+name+"-sub")
 	}
 
 	s, err := pubsub.NewSubscription(ctx, name, &pubsub.SubscriptionArgs{
-		Topic:              pulumi.String(args.Topic),
+		Topic:              args.Topic.PubSub.Name, // The GCP topic name
 		AckDeadlineSeconds: pulumi.Int(300),
 		RetryPolicy: pubsub.SubscriptionRetryPolicyArgs{
 			MinimumBackoff: pulumi.String("15s"),
@@ -118,9 +111,9 @@ func NewPubSubSubscription(ctx *pulumi.Context, name string, args *PubSubSubscri
 		},
 		PushConfig: pubsub.SubscriptionPushConfigArgs{
 			OidcToken: pubsub.SubscriptionPushConfigOidcTokenArgs{
-				ServiceAccountEmail: invokerAccount.Email,
+				ServiceAccountEmail: args.InvokerAccount.Email,
 			},
-			PushEndpoint: pulumi.Sprintf("%s/x-nitric-topic/%s", args.Function.Url, args.Topic),
+			PushEndpoint: pulumi.Sprintf("%s/x-nitric-topic/%s", args.Function.Url, args.Topic.Name),
 		},
 		ExpirationPolicy: &pubsub.SubscriptionExpirationPolicyArgs{
 			Ttl: pulumi.String(""),

--- a/cloud/gcp/deploy/exec/cloudrun.go
+++ b/cloud/gcp/deploy/exec/cloudrun.go
@@ -65,7 +65,9 @@ func GetPerms() []string {
 		"iam.serviceAccounts.signBlob",
 		// Basic list permissions
 		"pubsub.topics.list",
+		"pubsub.topics.get",
 		"pubsub.snapshots.list",
+		"pubsub.subscriptions.get",
 		"resourcemanager.projects.get",
 		"secretmanager.secrets.list",
 		"apigateway.gateways.list",

--- a/cloud/gcp/deploy/queue/pubsub.go
+++ b/cloud/gcp/deploy/queue/pubsub.go
@@ -17,6 +17,8 @@
 package queue
 
 import (
+	"fmt"
+
 	common "github.com/nitrictech/nitric/cloud/common/deploy/tags"
 	v1 "github.com/nitrictech/nitric/core/pkg/api/nitric/deploy/v1"
 	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/pubsub"
@@ -34,8 +36,7 @@ type PubSubTopic struct {
 type PubSubTopicArgs struct {
 	Location string
 	StackID  pulumi.StringInput
-
-	Queue *v1.Queue
+	Queue    *v1.Queue
 }
 
 func NewPubSubTopic(ctx *pulumi.Context, name string, args *PubSubTopicArgs, opts ...pulumi.ResourceOption) (*PubSubTopic, error) {
@@ -49,17 +50,18 @@ func NewPubSubTopic(ctx *pulumi.Context, name string, args *PubSubTopicArgs, opt
 	}
 
 	res.PubSub, err = pubsub.NewTopic(ctx, name, &pubsub.TopicArgs{
-		Name:   pulumi.String(name),
 		Labels: common.Tags(ctx, args.StackID, name),
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	res.Subscription, err = pubsub.NewSubscription(ctx, name+"-sub", &pubsub.SubscriptionArgs{
-		Name:   pulumi.Sprintf("%s-nitricqueue", name),
+	res.Subscription, err = pubsub.NewSubscription(ctx, fmt.Sprintf("%s-nitricqueue", name), &pubsub.SubscriptionArgs{
 		Topic:  res.PubSub.Name,
-		Labels: common.Tags(ctx, args.StackID, name+"-sub"),
+		Labels: common.Tags(ctx, args.StackID, name),
+		ExpirationPolicy: &pubsub.SubscriptionExpirationPolicyArgs{
+			Ttl: pulumi.String(""),
+		},
 	})
 	if err != nil {
 		return nil, err

--- a/cloud/gcp/deploy/up.go
+++ b/cloud/gcp/deploy/up.go
@@ -320,8 +320,7 @@ func (d *DeployServer) Up(request *deploy.DeployUpRequest, stream deploy.DeployS
 					return err
 				}
 
-
-				var invokerAccount *serviceaccount.Account				
+				var invokerAccount *serviceaccount.Account
 				for _, sub := range t.Topic.Subscriptions {
 					if invokerAccount == nil {
 						invokerAccount, err = serviceaccount.NewAccount(ctx, "subscription-invokeracct", &serviceaccount.AccountArgs{
@@ -340,8 +339,8 @@ func (d *DeployServer) Up(request *deploy.DeployUpRequest, stream deploy.DeployS
 					}
 
 					_, err = events.NewPubSubPushSubscription(ctx, subName, &events.PubSubSubscriptionArgs{
-						Topic:    topics[res.Name],
-						Function: unit,
+						Topic:          topics[res.Name],
+						Function:       unit,
 						InvokerAccount: invokerAccount,
 					}, defaultResourceOptions)
 					if err != nil {

--- a/cloud/gcp/deploy/up.go
+++ b/cloud/gcp/deploy/up.go
@@ -320,18 +320,9 @@ func (d *DeployServer) Up(request *deploy.DeployUpRequest, stream deploy.DeployS
 					return err
 				}
 
-				var invokerAccount *serviceaccount.Account
 				for _, sub := range t.Topic.Subscriptions {
-					if invokerAccount == nil {
-						invokerAccount, err = serviceaccount.NewAccount(ctx, "subscription-invokeracct", &serviceaccount.AccountArgs{
-							AccountId: pulumi.String("subscription-invokeracct"),
-						})
-						if err != nil {
-							return fmt.Errorf("error creating subscription account")
-						}
-					}
-
 					subName := events.GetSubName(sub.GetExecutionUnit(), res.Name)
+
 					// Get the deployed execution unit
 					unit, ok := execs[sub.GetExecutionUnit()]
 					if !ok {
@@ -339,9 +330,8 @@ func (d *DeployServer) Up(request *deploy.DeployUpRequest, stream deploy.DeployS
 					}
 
 					_, err = events.NewPubSubPushSubscription(ctx, subName, &events.PubSubSubscriptionArgs{
-						Topic:          topics[res.Name],
-						Function:       unit,
-						InvokerAccount: invokerAccount,
+						Topic:    topics[res.Name],
+						Function: unit,
 					}, defaultResourceOptions)
 					if err != nil {
 						return err

--- a/cloud/gcp/ifaces/pubsub/adapters.go
+++ b/cloud/gcp/ifaces/pubsub/adapters.go
@@ -89,12 +89,30 @@ func (t topic) ID() string {
 	return t.Topic.ID()
 }
 
+func (t topic) Labels(ctx context.Context) (map[string]string, error) {
+	config, err := t.Config(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return config.Labels, nil
+}
+
 func (s subscription) ID() string {
 	return s.Subscription.ID()
 }
 
 func (s subscription) String() string {
 	return s.Subscription.String()
+}
+
+func (s subscription) Labels(ctx context.Context) (map[string]string, error) {
+	config, err := s.Subscription.Config(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return config.Labels, nil
 }
 
 func (m message) ID() string {

--- a/cloud/gcp/ifaces/pubsub/ifaces.go
+++ b/cloud/gcp/ifaces/pubsub/ifaces.go
@@ -23,11 +23,8 @@ import (
 )
 
 type PubsubClient interface {
-	// CreateTopic(ctx context.Context, topicID string) (Topic, error)
 	Topic(id string) Topic
 	Topics(ctx context.Context) TopicIterator
-	// CreateSubscription(ctx context.Context, id string, cfg SubscriptionConfig) (Subscription, error)
-	// Subscription(id string) Subscription
 }
 
 type TopicIterator interface {
@@ -40,6 +37,7 @@ type Topic interface {
 	Exists(ctx context.Context) (bool, error)
 	Subscriptions(ctx context.Context) SubscriptionIterator
 	ID() string
+	Labels(ctx context.Context) (map[string]string, error)
 }
 
 type SubscriptionIterator interface {
@@ -49,6 +47,7 @@ type SubscriptionIterator interface {
 type Subscription interface {
 	ID() string
 	String() string
+	Labels(ctx context.Context) (map[string]string, error)
 }
 
 type Message interface {

--- a/cloud/gcp/mocks/pubsub/mock.go
+++ b/cloud/gcp/mocks/pubsub/mock.go
@@ -153,6 +153,21 @@ func (mr *MockTopicMockRecorder) ID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ID", reflect.TypeOf((*MockTopic)(nil).ID))
 }
 
+// Labels mocks base method.
+func (m *MockTopic) Labels(arg0 context.Context) (map[string]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Labels", arg0)
+	ret0, _ := ret[0].(map[string]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Labels indicates an expected call of Labels.
+func (mr *MockTopicMockRecorder) Labels(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Labels", reflect.TypeOf((*MockTopic)(nil).Labels), arg0)
+}
+
 // Publish mocks base method.
 func (m *MockTopic) Publish(arg0 context.Context, arg1 ifaces_pubsub.Message) ifaces_pubsub.PublishResult {
 	m.ctrl.T.Helper()

--- a/cloud/gcp/runtime/events/pubsub.go
+++ b/cloud/gcp/runtime/events/pubsub.go
@@ -43,6 +43,38 @@ type PubsubEventService struct {
 	core.GcpProvider
 	client      ifaces_pubsub.PubsubClient
 	tasksClient ifaces_cloudtasks.CloudtasksClient
+	cache       map[string]ifaces_pubsub.Topic
+}
+
+func (s *PubsubEventService) getPubsubTopicFromName(topic string) (ifaces_pubsub.Topic, error) {
+	if s.cache == nil {
+		topics := s.client.Topics(context.Background())
+		s.cache = make(map[string]ifaces_pubsub.Topic)
+		for {
+			t, err := topics.Next()
+			if errors.Is(err, iterator.Done) {
+				break
+			}
+			if err != nil {
+				return nil, fmt.Errorf("an error occurred finding topic: %s; %w", topic, err)
+			}
+
+			labels, err := t.Labels(context.TODO())
+			if err != nil {
+				return nil, fmt.Errorf("an error occurred finding topic labels: %s; %w", topic, err)
+			}
+
+			if name, ok := labels["x-nitric-name"]; ok {
+				s.cache[name] = s.client.Topic(t.ID())
+			}
+		}
+	}
+
+	if topic, ok := s.cache[topic]; ok {
+		return topic, nil
+	}
+
+	return nil, fmt.Errorf("topic not found")
 }
 
 func (s *PubsubEventService) ListTopics(ctx context.Context) ([]string, error) {
@@ -76,9 +108,12 @@ type httpPubsubMessages struct {
 
 func (s *PubsubEventService) publish(ctx context.Context, topic string, pubsubMsg *pubsub.Message) error {
 	msg := ifaces_pubsub.AdaptPubsubMessage(pubsubMsg)
-	pubsubTopic := s.client.Topic(topic)
+	pubsubTopic, err := s.getPubsubTopicFromName(topic)
+	if err != nil {
+		return err
+	}
 
-	_, err := pubsubTopic.Publish(ctx, msg).Get(ctx)
+	_, err = pubsubTopic.Publish(ctx, msg).Get(ctx)
 	return err
 }
 
@@ -105,6 +140,11 @@ func (s *PubsubEventService) publishDelayed(ctx context.Context, topic string, d
 		return err
 	}
 
+	pubsubTopic, err := s.getPubsubTopicFromName(topic)
+	if err != nil {
+		return err
+	}
+
 	// Delay the message publishing
 	_, err = s.tasksClient.CreateTask(ctx, &tasks.CreateTaskRequest{
 		Parent: utils.GetEnv("DELAY_QUEUE_NAME", ""),
@@ -117,9 +157,8 @@ func (s *PubsubEventService) publishDelayed(ctx context.Context, topic string, d
 						},
 					},
 					HttpMethod: tasks.HttpMethod_POST,
-					Url:        fmt.Sprintf("https://pubsub.googleapis.com/v1/projects/%s/topics/%s:publish", projectId, topic),
-					// TODO: Add message body with attributes
-					Body: jsonBody,
+					Url:        fmt.Sprintf("https://pubsub.googleapis.com/v1/projects/%s/topics/%s:publish", projectId, pubsubTopic.String()),
+					Body:       jsonBody,
 				},
 			},
 			// schedule for the future

--- a/cloud/gcp/runtime/events/pubsub.go
+++ b/cloud/gcp/runtime/events/pubsub.go
@@ -65,7 +65,7 @@ func (s *PubsubEventService) getPubsubTopicFromName(topic string) (ifaces_pubsub
 			}
 
 			if name, ok := labels["x-nitric-name"]; ok {
-				s.cache[name] = s.client.Topic(t.ID())
+				s.cache[name] = t
 			}
 		}
 	}

--- a/cloud/gcp/runtime/gateway/http.go
+++ b/cloud/gcp/runtime/gateway/http.go
@@ -58,6 +58,9 @@ func (g *gcpMiddleware) handleSubscription(process pool.WorkerPool) fasthttp.Req
 		if err := json.Unmarshal(bodyBytes, &pubsubEvent); err == nil && pubsubEvent.Subscription != "" {
 			// We have an event from pubsub here...
 			topicName := ctx.UserValue("name").(string)
+			if topicName == "" {
+				ctx.Error("Can not handle event for empty topic", 400)
+			}
 
 			event := &v1.TriggerRequest{
 				Data: pubsubEvent.Message.Data,
@@ -99,6 +102,9 @@ func (g *gcpMiddleware) handleSubscription(process pool.WorkerPool) fasthttp.Req
 func (g *gcpMiddleware) handleSchedule(process pool.WorkerPool) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {
 		scheduleName := ctx.UserValue("name").(string)
+		if scheduleName == "" {
+			ctx.Error("Can not handle event for empty schedule", 400)
+		}
 
 		evt := &v1.TriggerRequest{
 			// Send empty data for now (no reason to send data for schedules at the moment)

--- a/cloud/gcp/runtime/queue/pubsub.go
+++ b/cloud/gcp/runtime/queue/pubsub.go
@@ -64,7 +64,7 @@ func (s *PubsubQueueService) getPubsubTopicFromName(queue string) (ifaces_pubsub
 			}
 
 			if name, ok := labels["x-nitric-name"]; ok {
-				s.cache[name] = s.client.Topic(t.ID())
+				s.cache[name] = t
 			}
 		}
 	}

--- a/cloud/gcp/runtime/queue/pubsub.go
+++ b/cloud/gcp/runtime/queue/pubsub.go
@@ -39,12 +39,81 @@ type PubsubQueueService struct {
 	client              ifaces_pubsub.PubsubClient
 	newSubscriberClient func(ctx context.Context, opts ...option.ClientOption) (ifaces_pubsub.SubscriberClient, error)
 	projectId           string
+	cache               map[string]ifaces_pubsub.Topic
 }
 
-// TODO: clearly document the reason for this subscription.
-// Get the default Nitric Queue Subscription name for a given queue name.
-func generateQueueSubscription(queue string) string {
-	return fmt.Sprintf("%s-nitricqueue", queue)
+// Retrieves the Nitric "Queue Topic" for the specified queue (PubSub Topic).
+//
+// This retrieves the default Nitric Queue for the Topic based on tagging conventions.
+func (s *PubsubQueueService) getPubsubTopicFromName(queue string) (ifaces_pubsub.Topic, error) {
+	if s.cache == nil {
+		topics := s.client.Topics(context.Background())
+		s.cache = make(map[string]ifaces_pubsub.Topic)
+		for {
+			t, err := topics.Next()
+			if errors.Is(err, iterator.Done) {
+				break
+			}
+			if err != nil {
+				return nil, fmt.Errorf("an error occurred finding queue: %s; %w", queue, err)
+			}
+
+			labels, err := t.Labels(context.TODO())
+			if err != nil {
+				return nil, fmt.Errorf("an error occurred finding queue labels: %s; %w", queue, err)
+			}
+
+			if name, ok := labels["x-nitric-name"]; ok {
+				s.cache[name] = s.client.Topic(t.ID())
+			}
+		}
+	}
+
+	if t, ok := s.cache[queue]; ok {
+		return t, nil
+	}
+
+	return nil, fmt.Errorf("queue not found")
+}
+
+// Retrieves the Nitric "Queue Subscription" for the specified queue (PubSub Topic).
+//
+// GCP PubSub requires a Subscription in order to Pull messages from a Topic.
+// we use this behavior to emulate a queue.
+//
+// This retrieves the default Nitric Pull subscription for the Topic base on convention.
+func (s *PubsubQueueService) getQueueSubscription(ctx context.Context, queue string) (ifaces_pubsub.Subscription, error) {
+	// We'll be using pubsub with pull subscribers to facilitate queue functionality
+	topic, err := s.getPubsubTopicFromName(queue)
+	if err != nil {
+		return nil, err
+	}
+
+	subsIt := topic.Subscriptions(ctx)
+
+	for {
+		sub, err := subsIt.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve pull subscription for topic: %s\n%w", topic.ID(), err)
+		}
+
+		labels, err := sub.Labels(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve pull subscription labels for topic: %s\n%w", topic.ID(), err)
+		}
+
+		// The subscription's 'x-nitric-name' is its topic name
+		if name, ok := labels["x-nitric-name"]; ok {
+			if name == queue {
+				return sub, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("pull subscription not found, pull subscribers may not be configured for this topic")
 }
 
 func (s *PubsubQueueService) Send(ctx context.Context, queue string, task queue.NitricTask) error {
@@ -55,10 +124,10 @@ func (s *PubsubQueueService) Send(ctx context.Context, queue string, task queue.
 			"task":  task,
 		},
 	)
-	// We'll be using pubsub with pull subscribers to facilitate queue functionality
-	topic := s.client.Topic(queue)
 
-	if exists, err := topic.Exists(ctx); !exists || err != nil {
+	// We'll be using pubsub with pull subscribers to facilitate queue functionality
+	topic, err := s.getPubsubTopicFromName(queue)
+	if err != nil {
 		return newErr(
 			codes.NotFound,
 			"queue not found",
@@ -106,9 +175,8 @@ func (s *PubsubQueueService) SendBatch(ctx context.Context, q string, tasks []qu
 	)
 
 	// We'll be using pubsub with pull subscribers to facilitate queue functionality
-	topic := s.client.Topic(q)
-
-	if exists, err := topic.Exists(ctx); !exists || err != nil {
+	topic, err := s.getPubsubTopicFromName(q)
+	if err != nil {
 		return nil, newErr(
 			codes.NotFound,
 			"queue not found",
@@ -157,33 +225,6 @@ func (s *PubsubQueueService) SendBatch(ctx context.Context, q string, tasks []qu
 	return &queue.SendBatchResponse{
 		FailedTasks: failedTasks,
 	}, nil
-}
-
-// Retrieves the Nitric "Queue Subscription" for the specified queue (PubSub Topic).
-//
-// GCP PubSub requires a Subscription in order to Pull messages from a Topic.
-// we use this behavior to emulate a queue.
-//
-// This retrieves the default Nitric Pull subscription for the Topic base on convention.
-func (s *PubsubQueueService) getQueueSubscription(ctx context.Context, q string) (ifaces_pubsub.Subscription, error) {
-	topic := s.client.Topic(q)
-	subsIt := topic.Subscriptions(ctx)
-
-	for {
-		sub, err := subsIt.Next()
-		if errors.Is(err, iterator.Done) {
-			break
-		}
-		if err != nil {
-			return nil, fmt.Errorf("failed to retrieve pull subscription for topic: %s\n%w", topic.ID(), err)
-		}
-		queueSubName := generateQueueSubscription(q)
-		if sub.ID() == queueSubName {
-			return sub, nil
-		}
-	}
-
-	return nil, fmt.Errorf("pull subscription not found, pull subscribers may not be configured for this topic")
 }
 
 // Receives a collection of tasks off a given queue.
@@ -269,17 +310,17 @@ func (s *PubsubQueueService) Receive(ctx context.Context, options queue.ReceiveO
 }
 
 // Completes a previously popped queue item
-func (s *PubsubQueueService) Complete(ctx context.Context, q string, leaseId string) error {
+func (s *PubsubQueueService) Complete(ctx context.Context, queue string, leaseId string) error {
 	newErr := errors.ErrorsWithScope(
 		"PubsubQueueService.Complete",
 		map[string]interface{}{
-			"queue":   q,
+			"queue":   queue,
 			"leaseId": leaseId,
 		},
 	)
 
 	// Find the generic pull subscription for the provided topic (queue)
-	queueSubscription, err := s.getQueueSubscription(ctx, q)
+	queueSubscription, err := s.getQueueSubscription(ctx, queue)
 	if err != nil {
 		return newErr(
 			codes.NotFound,


### PR DESCRIPTION
Closes #416
- Adds name resolution to GCP topics (includes queues). This will stop conflicts when deploying the same project to GCP twice. 
- Stop queues expiring after 31 days of inactivity