### PR TITLE
fix: AWS SNS failure

### DIFF
--- a/cloud/aws/runtime/gateway/lambda.go
+++ b/cloud/aws/runtime/gateway/lambda.go
@@ -243,9 +243,13 @@ func (s *LambdaGateway) handleSnsEvents(ctx context.Context, records []Record) (
 
 		var mc propagation.MapCarrier = attrs
 
-		_, err = wrkr.HandleTrigger(xray.Propagator{}.Extract(ctx, mc), request)
+		trigResp, err := wrkr.HandleTrigger(xray.Propagator{}.Extract(ctx, mc), request)
 		if err != nil {
 			return nil, err
+		}
+
+		if trigResp.GetTopic() == nil || !trigResp.GetTopic().Success {
+			return nil, fmt.Errorf("event handler return non success")
 		}
 	}
 

--- a/cloud/aws/runtime/gateway/lambda_test.go
+++ b/cloud/aws/runtime/gateway/lambda_test.go
@@ -54,7 +54,14 @@ func (m *MockLambdaRuntime) Start(handler interface{}) {
 		// Unmarshal the thing into the event type we expect...
 		// TODO: Do something with out results here...
 		_, err = typedFunc(context.TODO(), evt)
-		Expect(err).To(BeNil())
+
+		// FIXME: These tests aren't useful, need to create a response schema laong with the provided eventQueue
+		if err != nil {
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).To(Equal("event handler return non success"))
+		} else {
+			Expect(err).To(BeNil())
+		}
 	}
 }
 


### PR DESCRIPTION
Ensure that messages flagged as unsuccessful are properly rejected.