### PR TITLE
feat(aws): allow existing secret import

### DIFF
--- a/cloud/aws/deploy/config/config.go
+++ b/cloud/aws/deploy/config/config.go
@@ -22,8 +22,14 @@ import (
 	"github.com/nitrictech/nitric/cloud/common/deploy/config"
 )
 
+type AwsImports struct {
+	// A map of nitric names to ARNs
+	Secrets map[string]string
+}
+
 type AwsConfig struct {
 	ScheduleTimezone string `mapstructure:"schedule-timezone,omitempty"`
+	Imports          AwsImports
 	config.AbstractConfig[*AwsConfigItem]
 }
 

--- a/cloud/aws/deploy/config/config.go
+++ b/cloud/aws/deploy/config/config.go
@@ -29,7 +29,7 @@ type AwsImports struct {
 
 type AwsConfig struct {
 	ScheduleTimezone string `mapstructure:"schedule-timezone,omitempty"`
-	Imports          AwsImports
+	Import           AwsImports
 	config.AbstractConfig[*AwsConfigItem]
 }
 

--- a/cloud/aws/deploy/secret/secretsmanager.go
+++ b/cloud/aws/deploy/secret/secretsmanager.go
@@ -70,7 +70,6 @@ func NewSecretsManagerSecret(ctx *pulumi.Context, name string, args *SecretsMana
 					"x-nitric-stack":      stackId,
 				}),
 			})
-
 			if err != nil {
 				return false, err
 			}

--- a/cloud/aws/deploy/up.go
+++ b/cloud/aws/deploy/up.go
@@ -117,6 +117,7 @@ func (d *DeployServer) Up(request *deploy.DeployUpRequest, stream deploy.DeployS
 					StackID: stackID,
 					Secret:  c.Secret,
 					Import:  importArn,
+					Client:  resourceTaggingClient,
 				})
 				if err != nil {
 					return err

--- a/cloud/aws/deploy/up.go
+++ b/cloud/aws/deploy/up.go
@@ -109,8 +109,8 @@ func (d *DeployServer) Up(request *deploy.DeployUpRequest, stream deploy.DeployS
 			case *deploy.Resource_Secret:
 				importArn := ""
 
-				if config.Imports.Secrets != nil {
-					importArn = config.Imports.Secrets[res.Name]
+				if config.Import.Secrets != nil {
+					importArn = config.Import.Secrets[res.Name]
 				}
 
 				secrets[res.Name], err = secret.NewSecretsManagerSecret(ctx, res.Name, &secret.SecretsManagerSecretArgs{

--- a/cloud/aws/deploy/up.go
+++ b/cloud/aws/deploy/up.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/nitrictech/nitric/cloud/aws/deploy/api"
 	"github.com/nitrictech/nitric/cloud/aws/deploy/bucket"
@@ -76,6 +77,7 @@ func (d *DeployServer) Up(request *deploy.DeployUpRequest, stream deploy.DeployS
 		SharedConfigState: session.SharedConfigEnable,
 	}))
 	lambdaClient := lambda.New(sess, &aws.Config{Region: aws.String(details.Region)})
+	resourceTaggingClient := resourcegroupstaggingapi.New(sess)
 
 	pulumiStack, err := auto.UpsertStackInlineSource(context.TODO(), details.FullStackName, details.Project, func(ctx *pulumi.Context) error {
 		principals := map[v1.ResourceType]map[string]*iam.Role{}
@@ -105,9 +107,16 @@ func (d *DeployServer) Up(request *deploy.DeployUpRequest, stream deploy.DeployS
 		for _, res := range request.Spec.Resources {
 			switch c := res.Config.(type) {
 			case *deploy.Resource_Secret:
+				importArn := ""
+
+				if config.Imports.Secrets != nil {
+					importArn = config.Imports.Secrets[res.Name]
+				}
+
 				secrets[res.Name], err = secret.NewSecretsManagerSecret(ctx, res.Name, &secret.SecretsManagerSecretArgs{
 					StackID: stackID,
 					Secret:  c.Secret,
+					Import:  importArn,
 				})
 				if err != nil {
 					return err

--- a/cloud/aws/runtime/secret/secrets_manager.go
+++ b/cloud/aws/runtime/secret/secrets_manager.go
@@ -153,6 +153,12 @@ func (s *secretsManagerSecretService) Access(ctx context.Context, sv *secret.Sec
 		)
 	}
 
+	returnValue := result.SecretBinary
+
+	if returnValue == nil && result.SecretString != nil {
+		returnValue = []byte(*result.SecretString)
+	}
+
 	return &secret.SecretAccessResponse{
 		SecretVersion: &secret.SecretVersion{
 			Secret: &secret.Secret{
@@ -160,7 +166,7 @@ func (s *secretsManagerSecretService) Access(ctx context.Context, sv *secret.Sec
 			},
 			Version: *result.VersionId,
 		},
-		Value: result.SecretBinary,
+		Value: returnValue,
 	}, nil
 }
 


### PR DESCRIPTION
Example config

```yaml
name: test-aws
provider: nitric/aws@0.0.1
region: ap-southeast-2
import:
  secrets:
    test: <your_secrets_arn>
```

Behaviours:

 - If you add an import over an existing nitric secret, that secret will be deleted and replaced by the imported secret.
 - If you remove an imported secret that secret will not be deleted, but a new nitric secret will be created to take its place.
 - Imported secrets will be tagged as part of the deployment process. With essential nitric tags
 - If an imported secret cannot be located, deployment will fail.