### PR TITLE
feat: AWS Lambda VPC config

### DIFF
--- a/cloud/aws/deploy/config/config.go
+++ b/cloud/aws/deploy/config/config.go
@@ -40,7 +40,6 @@ type AwsConfigItem struct {
 }
 
 type AwsLambdaVpcConfig struct {
-	VpcId            string   `mapstructure:"id"`
 	SubnetIds        []string `mapstructure:"subnet-ids"`
 	SecurityGroupIds []string `mapstructure:"security-group-ids"`
 }

--- a/cloud/aws/deploy/config/config.go
+++ b/cloud/aws/deploy/config/config.go
@@ -28,10 +28,10 @@ type AwsImports struct {
 }
 
 type AwsConfig struct {
-	ScheduleTimezone string `mapstructure:"schedule-timezone,omitempty"`
-	Import           AwsImports
-	Refresh          bool
-	config.AbstractConfig[*AwsConfigItem]
+	ScheduleTimezone                      string `mapstructure:"schedule-timezone,omitempty"`
+	Import                                AwsImports
+	Refresh                               bool
+	config.AbstractConfig[*AwsConfigItem] `mapstructure:"config,squash"`
 }
 
 type AwsConfigItem struct {

--- a/cloud/aws/deploy/config/config.go
+++ b/cloud/aws/deploy/config/config.go
@@ -39,10 +39,17 @@ type AwsConfigItem struct {
 	Telemetry int
 }
 
+type AwsLambdaVpcConfig struct {
+	VpcId            string
+	SubnetIds        []string
+	SecurityGroupIds []string
+}
+
 type AwsLambdaConfig struct {
 	Memory                int
 	Timeout               int
-	ProvisionedConcurreny int `mapstructure:"provisioned-concurrency"`
+	ProvisionedConcurreny int                 `mapstructure:"provisioned-concurrency"`
+	Vpc                   *AwsLambdaVpcConfig `mapstructure:"vpc,omitempty"`
 }
 
 var defaultLambdaConfig = &AwsLambdaConfig{

--- a/cloud/aws/deploy/config/config.go
+++ b/cloud/aws/deploy/config/config.go
@@ -40,9 +40,9 @@ type AwsConfigItem struct {
 }
 
 type AwsLambdaVpcConfig struct {
-	VpcId            string
-	SubnetIds        []string
-	SecurityGroupIds []string
+	VpcId            string   `mapstructure:"id"`
+	SubnetIds        []string `mapstructure:"subnet-ids"`
+	SecurityGroupIds []string `mapstructure:"security-group-ids"`
 }
 
 type AwsLambdaConfig struct {

--- a/cloud/aws/deploy/exec/lambda.go
+++ b/cloud/aws/deploy/exec/lambda.go
@@ -159,6 +159,15 @@ func NewLambdaExecutionUnit(ctx *pulumi.Context, name string, args *LambdaExecUn
 			SubnetIds:        pulumi.ToStringArray(args.Config.Vpc.SubnetIds),
 			SecurityGroupIds: pulumi.ToStringArray(args.Config.Vpc.SecurityGroupIds),
 		}
+
+		// Create a policy attachment for VPC access
+		_, err = iam.NewRolePolicyAttachment(ctx, name+"VPCAccessExecutionRole", &iam.RolePolicyAttachmentArgs{
+			PolicyArn: iam.ManagedPolicyAWSLambdaVPCAccessExecutionRole,
+			Role:      res.Role.ID(),
+		}, opts...)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	res.Function, err = awslambda.NewFunction(ctx, name, &awslambda.FunctionArgs{

--- a/cloud/aws/deploy/exec/lambda.go
+++ b/cloud/aws/deploy/exec/lambda.go
@@ -155,7 +155,6 @@ func NewLambdaExecutionUnit(ctx *pulumi.Context, name string, args *LambdaExecUn
 	var vpcConfig *awslambda.FunctionVpcConfigArgs = nil
 	if args.Config.Vpc != nil {
 		vpcConfig = &awslambda.FunctionVpcConfigArgs{
-			VpcId:            pulumi.String(args.Config.Vpc.VpcId),
 			SubnetIds:        pulumi.ToStringArray(args.Config.Vpc.SubnetIds),
 			SecurityGroupIds: pulumi.ToStringArray(args.Config.Vpc.SecurityGroupIds),
 		}

--- a/cloud/azure/deploy/config/config.go
+++ b/cloud/azure/deploy/config/config.go
@@ -35,8 +35,8 @@ type AzureContainerAppsConfig struct {
 }
 
 type AzureConfig struct {
-	Refresh bool
-	config.AbstractConfig[*AzureConfigItem]
+	Refresh                                 bool
+	config.AbstractConfig[*AzureConfigItem] `mapstructure:"config,squash"`
 }
 
 var defaultContainerAppsConfig = &AzureContainerAppsConfig{

--- a/cloud/gcp/deploy/config/config.go
+++ b/cloud/gcp/deploy/config/config.go
@@ -36,9 +36,9 @@ type GcpCloudRunConfig struct {
 }
 
 type GcpConfig struct {
-	config.AbstractConfig[*GcpConfigItem]
-	ScheduleTimezone string `mapstructure:"schedule-timezone"`
-	Refresh          bool
+	config.AbstractConfig[*GcpConfigItem] `mapstructure:"config,squash"`
+	ScheduleTimezone                      string `mapstructure:"schedule-timezone"`
+	Refresh                               bool
 }
 
 var defaultCloudRunConfig = &GcpCloudRunConfig{


### PR DESCRIPTION
Proposal for adding VPC configuration for AWS Lambda to aws stack configuration:

```yaml
name: example-aws
provider: nitric/aws@0.28.0
region: us-east2
config:
  # :eyes: This needs to match a function type from your project definition.
  database-access:
    lambda:
      vpc:
        security-group-ids:
          - example-id
        subnet-ids:
          - example-id
```

This should allow lambdas deployed with nitric to access existing resources within VPCs.