### PR TITLE
fix: add docker:host to pulumi config to windows deploy

### DIFF
--- a/cloud/aws/deploy/up.go
+++ b/cloud/aws/deploy/up.go
@@ -19,6 +19,7 @@ package deploy
 import (
 	"context"
 	"fmt"
+	osRuntime "runtime"
 	"runtime/debug"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -416,6 +417,13 @@ func (d *DeployServer) Up(request *deploy.DeployUpRequest, stream deploy.DeployS
 	}
 
 	_ = pulumiStack.SetConfig(context.TODO(), "aws:region", auto.ConfigValue{Value: details.Region})
+
+	if osRuntime.GOOS == "windows" {
+		err = pulumiStack.SetConfig(context.TODO(), "docker:host", auto.ConfigValue{Value: "npipe:////.//pipe//docker_engine"})
+		if err != nil {
+			return err
+		}
+	}
 
 	messageWriter := &pulumiutils.UpStreamMessageWriter{
 		Stream: stream,

--- a/cloud/azure/deploy/up.go
+++ b/cloud/azure/deploy/up.go
@@ -17,6 +17,7 @@ package deploy
 import (
 	"context"
 	"fmt"
+	osRuntime "runtime"
 	"runtime/debug"
 	"strings"
 
@@ -409,6 +410,13 @@ func (d *DeployServer) Up(request *deploy.DeployUpRequest, stream deploy.DeployS
 
 	_ = pulumiStack.SetConfig(context.TODO(), "azure-native:location", auto.ConfigValue{Value: details.Region})
 	_ = pulumiStack.SetConfig(context.TODO(), "azure:location", auto.ConfigValue{Value: details.Region})
+
+	if osRuntime.GOOS == "windows" {
+		err = pulumiStack.SetConfig(context.TODO(), "docker:host", auto.ConfigValue{Value: "npipe:////.//pipe//docker_engine"})
+		if err != nil {
+			return err
+		}
+	}
 
 	messageWriter := &pulumiutils.UpStreamMessageWriter{
 		Stream: stream,

--- a/cloud/gcp/deploy/up.go
+++ b/cloud/gcp/deploy/up.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	osRuntime "runtime"
 	"runtime/debug"
 	"strings"
 
@@ -482,6 +483,13 @@ func (d *DeployServer) Up(request *deploy.DeployUpRequest, stream deploy.DeployS
 	err = pulumiStack.SetConfig(context.TODO(), "gcp:project", auto.ConfigValue{Value: details.ProjectId})
 	if err != nil {
 		return err
+	}
+
+	if osRuntime.GOOS == "windows" {
+		err = pulumiStack.SetConfig(context.TODO(), "docker:host", auto.ConfigValue{Value: "npipe:////.//pipe//docker_engine"})
+		if err != nil {
+			return err
+		}
 	}
 
 	messageWriter := &pulumiutils.UpStreamMessageWriter{


### PR DESCRIPTION
<!---
Thanks for your contribution! Please ensure that you have read the [Contribution guide](https://github.com/nitrictech/nitric/blob/main/CONTRIBUTING.md).
-->

# Description

On windows 10 docker, the protocol is not available when using nitric up.

The fix sets the docker host to "npipe:////.//pipe//docker_engine" on windows only. As seen here: https://github.com/pulumi/pulumi/issues/8626

Needs testing.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
