### PR TITLE
fix: make lambda exec unit resource more reusable.

### DIFF
--- a/cloud/aws/deploy/exec/lambda.go
+++ b/cloud/aws/deploy/exec/lambda.go
@@ -42,7 +42,7 @@ type LambdaExecUnitArgs struct {
 	// Image needs to be built and uploaded first
 	DockerImage *image.Image
 	Compute     *v1.ExecutionUnit
-	EnvMap      map[string]string
+	EnvMap      pulumi.StringMap
 	Config      config.AwsLambdaConfig
 }
 
@@ -152,7 +152,7 @@ func NewLambdaExecutionUnit(ctx *pulumi.Context, name string, args *LambdaExecUn
 		"NITRIC_HTTP_PROXY_PORT": pulumi.String(fmt.Sprint(3000)),
 	}
 	for k, v := range args.EnvMap {
-		envVars[k] = pulumi.String(v)
+		envVars[k] = v
 	}
 
 	var vpcConfig *awslambda.FunctionVpcConfigArgs = nil

--- a/cloud/aws/deploy/up.go
+++ b/cloud/aws/deploy/up.go
@@ -226,7 +226,7 @@ func (d *DeployServer) Up(request *deploy.DeployUpRequest, stream deploy.DeployS
 						DockerImage: image,
 						StackID:     stackID,
 						Compute:     eu.ExecutionUnit,
-						EnvMap:      eu.ExecutionUnit.Env,
+						EnvMap:      pulumi.ToStringMap(eu.ExecutionUnit.Env),
 						Client:      lambdaClient,
 						Config:      *typeConfig.Lambda,
 					})


### PR DESCRIPTION
Just ran into this developing a provider. Was unable to properly inject external environment variables from other Pulumi deployed resources.