### PR TITLE
fix: reduce default max instances to 10 to stop cpu instance error

### DIFF
--- a/cloud/gcp/deploy/config/config.go
+++ b/cloud/gcp/deploy/config/config.go
@@ -45,7 +45,7 @@ var defaultCloudRunConfig = &GcpCloudRunConfig{
 	Memory:       512,
 	Timeout:      300,
 	MinInstances: 0,
-	MaxInstances: 80,
+	MaxInstances: 10,
 	Concurrency:  300,
 }
 


### PR DESCRIPTION
Closes https://github.com/nitrictech/nitric/issues/547