### PR TITLE
refactor: remove runtime binaries from main deployment package paths

### DIFF
--- a/cloud/aws/Makefile
+++ b/cloud/aws/Makefile
@@ -42,15 +42,15 @@ sourcefiles := $(shell find . -type f -name "*.go" -o -name "*.dockerfile")
 
 fmt:
 	@go run github.com/google/addlicense -c "Nitric Technologies Pty Ltd." -y "2021" $(sourcefiles)
-	@touch deploy/runtime-aws
+	@touch deploy/runtime/runtime-aws
 	$(GOLANGCI_LINT) run --fix
-	@rm deploy/runtime-aws
+	@rm deploy/runtime/runtime-aws
 
 lint:
 	@go run github.com/google/addlicense -check -c "Nitric Technologies Pty Ltd." -y "2021" $(sourcefiles)
-	@touch deploy/runtime-aws
+	@touch deploy/runtime/runtime-aws
 	$(GOLANGCI_LINT) run
-	@rm deploy/runtime-aws
+	@rm deploy/runtime/runtime-aws
 
 test: generate-mocks
 	@echo Running unit tests

--- a/cloud/aws/Makefile
+++ b/cloud/aws/Makefile
@@ -20,12 +20,12 @@ runtimebin:
 	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/runtime-aws -ldflags="-s -w -extldflags=-static" ./cmd/runtime
 
 predeploybin: runtimebin
-	@cp bin/runtime-aws deploy/runtime-aws
+	@cp bin/runtime-aws deploy/runtime/runtime-aws
 
 deploybin: predeploybin
 	@echo Building AWS Deployment Server
 	@CGO_ENABLED=0 go build -o bin/deploy-aws -ldflags="-s -w -extldflags=-static" -ldflags="-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=ignore" ./cmd/deploy
-	@rm deploy/runtime-aws
+	@rm deploy/runtime/runtime-aws
 
 .PHONY: install
 install: deploybin

--- a/cloud/aws/Makefile
+++ b/cloud/aws/Makefile
@@ -8,9 +8,9 @@ GOLANGCI_LINT ?= GOLANGCI_LINT_CACHE=$(GOLANGCI_LINT_CACHE) go run github.com/go
 binaries: deploybin
 
 sec:
-	@touch deploy/runtime-aws
+	@touch deploy/runtime/runtime-aws
 	@go run github.com/securego/gosec/v2/cmd/gosec@latest -exclude-dir=tools ./...
-	@rm deploy/runtime-aws
+	@rm deploy/runtime/runtime-aws
 
 # build runtime binary directly into the deploy director so it can be embedded directly into the deployment engine binary
 # We only build a linux amd64 binary here to be packaged for cloud runtimes with docker

--- a/cloud/aws/cmd/deploy/main.go
+++ b/cloud/aws/cmd/deploy/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/nitrictech/nitric/cloud/aws/deploy"
+	"github.com/nitrictech/nitric/cloud/aws/deploy/runtime"
 	"github.com/nitrictech/nitric/cloud/common/deploy/provider"
 )
 
@@ -25,7 +26,7 @@ import (
 func main() {
 	awsStack := deploy.NewNitricAwsProvider()
 
-	providerServer := provider.NewPulumiProviderServer(awsStack)
+	providerServer := provider.NewPulumiProviderServer(awsStack, runtime.NitricAwsRuntime)
 
 	providerServer.Start()
 }

--- a/cloud/aws/deploy/bucket.go
+++ b/cloud/aws/deploy/bucket.go
@@ -108,28 +108,28 @@ func (a *NitricAwsPulumiProvider) Bucket(ctx *pulumi.Context, parent pulumi.Reso
 	opts := []pulumi.ResourceOption{pulumi.Parent(parent)}
 
 	bucket, err := s3.NewBucket(ctx, name, &s3.BucketArgs{
-		Tags: pulumi.ToStringMap(common.Tags(a.stackId, name, resources.Bucket)),
+		Tags: pulumi.ToStringMap(common.Tags(a.StackId, name, resources.Bucket)),
 	}, opts...)
 	if err != nil {
 		return err
 	}
 
-	a.buckets[name] = bucket
+	a.Buckets[name] = bucket
 
 	if len(config.Listeners) > 0 {
 		notificationName := fmt.Sprintf("notification-%s", name)
 		notification, err := createNotification(ctx, notificationName, &S3NotificationArgs{
-			StackID:   a.stackId,
-			Location:  a.region,
+			StackID:   a.StackId,
+			Location:  a.Region,
 			Bucket:    bucket,
-			Lambdas:   a.lambdas,
+			Lambdas:   a.Lambdas,
 			Listeners: config.Listeners,
 		}, opts...)
 		if err != nil {
 			return err
 		}
 
-		a.bucketNotifications[name] = notification
+		a.BucketNotifications[name] = notification
 	}
 
 	return nil

--- a/cloud/aws/deploy/deploy.go
+++ b/cloud/aws/deploy/deploy.go
@@ -50,10 +50,10 @@ import (
 
 type NitricAwsPulumiProvider struct {
 	StackId     string
-	projectName string
-	stackName   string
+	ProjectName string
+	StackName   string
 
-	fullStackName string
+	FullStackName string
 
 	AwsConfig *AwsConfig
 	Region    string
@@ -107,15 +107,15 @@ func (a *NitricAwsPulumiProvider) Init(attributes map[string]interface{}) error 
 	var isString bool
 
 	iProject, hasProject := attributes["project"]
-	a.projectName, isString = iProject.(string)
-	if !hasProject || !isString || a.projectName == "" {
+	a.ProjectName, isString = iProject.(string)
+	if !hasProject || !isString || a.ProjectName == "" {
 		// need a valid project name
 		return fmt.Errorf("project is not set or invalid")
 	}
 
 	iStack, hasStack := attributes["stack"]
-	a.stackName, isString = iStack.(string)
-	if !hasStack || !isString || a.stackName == "" {
+	a.StackName, isString = iStack.(string)
+	if !hasStack || !isString || a.StackName == "" {
 		// need a valid stack name
 		return fmt.Errorf("stack is not set or invalid")
 	}
@@ -123,7 +123,7 @@ func (a *NitricAwsPulumiProvider) Init(attributes map[string]interface{}) error 
 	// Backwards compatible stack name
 	// The existing providers in the CLI
 	// Use the combined project and stack name
-	a.fullStackName = fmt.Sprintf("%s-%s", a.projectName, a.stackName)
+	a.FullStackName = fmt.Sprintf("%s-%s", a.ProjectName, a.StackName)
 
 	return nil
 }

--- a/cloud/aws/deploy/deploy.go
+++ b/cloud/aws/deploy/deploy.go
@@ -30,6 +30,7 @@ import (
 	"github.com/nitrictech/nitric/cloud/aws/common"
 	"github.com/nitrictech/nitric/cloud/common/deploy"
 	"github.com/nitrictech/nitric/cloud/common/deploy/provider"
+	"github.com/nitrictech/nitric/cloud/common/deploy/pulumix"
 	"github.com/nitrictech/nitric/cloud/common/deploy/tags"
 	deploymentspb "github.com/nitrictech/nitric/core/pkg/proto/deployments/v1"
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/apigatewayv2"
@@ -128,7 +129,7 @@ func (a *NitricAwsPulumiProvider) Init(attributes map[string]interface{}) error 
 	return nil
 }
 
-func (a *NitricAwsPulumiProvider) Pre(ctx *pulumi.Context, resources []*deploymentspb.Resource) error {
+func (a *NitricAwsPulumiProvider) Pre(ctx *pulumi.Context, resources []*pulumix.NitricPulumiResource[any]) error {
 	// make our random stackId
 	stackRandId, err := random.NewRandomString(ctx, fmt.Sprintf("%s-stack-name", ctx.Stack()), &random.RandomStringArgs{
 		Special: pulumi.Bool(false),

--- a/cloud/aws/deploy/deploy.go
+++ b/cloud/aws/deploy/deploy.go
@@ -77,13 +77,6 @@ type NitricAwsPulumiProvider struct {
 	lambdaClient          lambdaiface.LambdaAPI
 }
 
-// Embeds the runtime directly into the deploytime binary
-// This way the versions will always match as they're always built and versioned together (as a single artifact)
-// This should also help with docker build speeds as the runtime has already been "downloaded"
-//
-//go:embed runtime-aws
-var runtime []byte
-
 var _ provider.NitricPulumiProvider = (*NitricAwsPulumiProvider)(nil)
 
 const pulumiAwsVersion = "6.6.0"

--- a/cloud/aws/deploy/deploy.go
+++ b/cloud/aws/deploy/deploy.go
@@ -49,27 +49,27 @@ import (
 )
 
 type NitricAwsPulumiProvider struct {
-	stackId     string
+	StackId     string
 	projectName string
 	stackName   string
 
 	fullStackName string
 
-	config *AwsConfig
-	region string
+	AwsConfig *AwsConfig
+	Region    string
 
-	ecrAuthToken        *ecr.GetAuthorizationTokenResult
-	lambdas             map[string]*lambda.Function
-	lambdaRoles         map[string]*iam.Role
-	httpProxies         map[string]*apigatewayv2.Api
-	apis                map[string]*apigatewayv2.Api
-	secrets             map[string]*secretsmanager.Secret
-	buckets             map[string]*s3.Bucket
-	bucketNotifications map[string]*s3.BucketNotification
-	topics              map[string]*topic
-	queues              map[string]*sqs.Queue
-	websockets          map[string]*apigatewayv2.Api
-	keyValueStores      map[string]*dynamodb.Table
+	EcrAuthToken        *ecr.GetAuthorizationTokenResult
+	Lambdas             map[string]*lambda.Function
+	LambdaRoles         map[string]*iam.Role
+	HttpProxies         map[string]*apigatewayv2.Api
+	Apis                map[string]*apigatewayv2.Api
+	Secrets             map[string]*secretsmanager.Secret
+	Buckets             map[string]*s3.Bucket
+	BucketNotifications map[string]*s3.BucketNotification
+	Topics              map[string]*topic
+	Queues              map[string]*sqs.Queue
+	Websockets          map[string]*apigatewayv2.Api
+	KeyValueStores      map[string]*dynamodb.Table
 
 	provider.NitricDefaultOrder
 
@@ -83,7 +83,7 @@ const pulumiAwsVersion = "6.6.0"
 
 func (a *NitricAwsPulumiProvider) Config() (auto.ConfigMap, error) {
 	return auto.ConfigMap{
-		"aws:region":     auto.ConfigValue{Value: a.region},
+		"aws:region":     auto.ConfigValue{Value: a.Region},
 		"aws:version":    auto.ConfigValue{Value: pulumiAwsVersion},
 		"docker:version": auto.ConfigValue{Value: deploy.PulumiDockerVersion},
 	}, nil
@@ -97,9 +97,9 @@ func (a *NitricAwsPulumiProvider) Init(attributes map[string]interface{}) error 
 		return fmt.Errorf("Missing region attribute")
 	}
 
-	a.region = region
+	a.Region = region
 
-	a.config, err = ConfigFromAttributes(attributes)
+	a.AwsConfig, err = ConfigFromAttributes(attributes)
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "Bad stack configuration: %s", err)
 	}
@@ -147,7 +147,7 @@ func (a *NitricAwsPulumiProvider) Pre(ctx *pulumi.Context, resources []*deployme
 		return id
 	})
 
-	a.stackId = <-stackIdChan
+	a.StackId = <-stackIdChan
 
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
@@ -155,9 +155,9 @@ func (a *NitricAwsPulumiProvider) Pre(ctx *pulumi.Context, resources []*deployme
 
 	a.resourceTaggingClient = resourcegroupstaggingapi.New(sess)
 
-	a.lambdaClient = lambdaClient.New(sess, &aws.Config{Region: aws.String(a.region)})
+	a.lambdaClient = lambdaClient.New(sess, &aws.Config{Region: aws.String(a.Region)})
 
-	a.ecrAuthToken, err = ecr.GetAuthorizationToken(ctx, &ecr.GetAuthorizationTokenArgs{})
+	a.EcrAuthToken, err = ecr.GetAuthorizationToken(ctx, &ecr.GetAuthorizationTokenArgs{})
 	if err != nil {
 		return err
 	}
@@ -185,31 +185,31 @@ func (a *NitricAwsPulumiProvider) Result(ctx *pulumi.Context) (pulumi.StringOutp
 	outputs := []interface{}{}
 
 	// Add APIs outputs
-	if len(a.apis) > 0 {
+	if len(a.Apis) > 0 {
 		outputs = append(outputs, pulumi.Sprintf("API Endpoints:\n──────────────"))
-		for apiName, api := range a.apis {
+		for apiName, api := range a.Apis {
 			outputs = append(outputs, pulumi.Sprintf("%s: %s", apiName, api.ApiEndpoint))
 		}
 	}
 
 	// Add HTTP Proxy outputs
-	if len(a.httpProxies) > 0 {
+	if len(a.HttpProxies) > 0 {
 		if len(outputs) > 0 {
 			outputs = append(outputs, "\n")
 		}
 		outputs = append(outputs, pulumi.Sprintf("HTTP Proxies:\n──────────────"))
-		for proxyName, proxy := range a.httpProxies {
+		for proxyName, proxy := range a.HttpProxies {
 			outputs = append(outputs, pulumi.Sprintf("%s: %s", proxyName, proxy.ApiEndpoint))
 		}
 	}
 
 	// Add Websocket outputs
-	if len(a.websockets) > 0 {
+	if len(a.Websockets) > 0 {
 		if len(outputs) > 0 {
 			outputs = append(outputs, "\n")
 		}
 		outputs = append(outputs, pulumi.Sprintf("Websockets:\n──────────────"))
-		for wsName, ws := range a.websockets {
+		for wsName, ws := range a.Websockets {
 			outputs = append(outputs, pulumi.Sprintf("%s: %s/%s", wsName, ws.ApiEndpoint, common.DefaultWsStageName))
 		}
 	}
@@ -232,16 +232,16 @@ func (a *NitricAwsPulumiProvider) Result(ctx *pulumi.Context) (pulumi.StringOutp
 
 func NewNitricAwsProvider() *NitricAwsPulumiProvider {
 	return &NitricAwsPulumiProvider{
-		lambdas:             make(map[string]*lambda.Function),
-		lambdaRoles:         make(map[string]*iam.Role),
-		apis:                make(map[string]*apigatewayv2.Api),
-		httpProxies:         make(map[string]*apigatewayv2.Api),
-		secrets:             make(map[string]*secretsmanager.Secret),
-		buckets:             make(map[string]*s3.Bucket),
-		bucketNotifications: make(map[string]*s3.BucketNotification),
-		websockets:          make(map[string]*apigatewayv2.Api),
-		topics:              make(map[string]*topic),
-		queues:              make(map[string]*sqs.Queue),
-		keyValueStores:      make(map[string]*dynamodb.Table),
+		Lambdas:             make(map[string]*lambda.Function),
+		LambdaRoles:         make(map[string]*iam.Role),
+		Apis:                make(map[string]*apigatewayv2.Api),
+		HttpProxies:         make(map[string]*apigatewayv2.Api),
+		Secrets:             make(map[string]*secretsmanager.Secret),
+		Buckets:             make(map[string]*s3.Bucket),
+		BucketNotifications: make(map[string]*s3.BucketNotification),
+		Websockets:          make(map[string]*apigatewayv2.Api),
+		Topics:              make(map[string]*topic),
+		Queues:              make(map[string]*sqs.Queue),
+		KeyValueStores:      make(map[string]*dynamodb.Table),
 	}
 }

--- a/cloud/aws/deploy/deploy.go
+++ b/cloud/aws/deploy/deploy.go
@@ -74,8 +74,8 @@ type NitricAwsPulumiProvider struct {
 
 	provider.NitricDefaultOrder
 
-	resourceTaggingClient *resourcegroupstaggingapi.ResourceGroupsTaggingAPI
-	lambdaClient          lambdaiface.LambdaAPI
+	ResourceTaggingClient *resourcegroupstaggingapi.ResourceGroupsTaggingAPI
+	LambdaClient          lambdaiface.LambdaAPI
 }
 
 var _ provider.NitricPulumiProvider = (*NitricAwsPulumiProvider)(nil)
@@ -154,9 +154,9 @@ func (a *NitricAwsPulumiProvider) Pre(ctx *pulumi.Context, resources []*pulumix.
 		SharedConfigState: session.SharedConfigEnable,
 	}))
 
-	a.resourceTaggingClient = resourcegroupstaggingapi.New(sess)
+	a.ResourceTaggingClient = resourcegroupstaggingapi.New(sess)
 
-	a.lambdaClient = lambdaClient.New(sess, &aws.Config{Region: aws.String(a.Region)})
+	a.LambdaClient = lambdaClient.New(sess, &aws.Config{Region: aws.String(a.Region)})
 
 	a.EcrAuthToken, err = ecr.GetAuthorizationToken(ctx, &ecr.GetAuthorizationTokenArgs{})
 	if err != nil {

--- a/cloud/aws/deploy/deploy.go
+++ b/cloud/aws/deploy/deploy.go
@@ -32,7 +32,6 @@ import (
 	"github.com/nitrictech/nitric/cloud/common/deploy/provider"
 	"github.com/nitrictech/nitric/cloud/common/deploy/pulumix"
 	"github.com/nitrictech/nitric/cloud/common/deploy/tags"
-	deploymentspb "github.com/nitrictech/nitric/core/pkg/proto/deployments/v1"
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/apigatewayv2"
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/dynamodb"
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ecr"
@@ -134,7 +133,7 @@ func (a *NitricAwsPulumiProvider) Pre(ctx *pulumi.Context, resources []*pulumix.
 	stackRandId, err := random.NewRandomString(ctx, fmt.Sprintf("%s-stack-name", ctx.Stack()), &random.RandomStringArgs{
 		Special: pulumi.Bool(false),
 		Length:  pulumi.Int(8),
-		Keepers: pulumi.ToStringMap(map[string]string{
+		Keepers: pulumi.ToMap(map[string]interface{}{
 			"stack-name": ctx.Stack(),
 		}),
 	})
@@ -165,13 +164,13 @@ func (a *NitricAwsPulumiProvider) Pre(ctx *pulumi.Context, resources []*pulumix.
 
 	// Create AWS Resource groups with our tags
 	_, err = resourcegroups.NewGroup(ctx, "stack-resource-group", &resourcegroups.GroupArgs{
-		Name:        pulumi.String(a.fullStackName),
-		Description: pulumi.Sprintf("All deployed resources for the %s nitric stack", a.fullStackName),
+		Name:        pulumi.String(a.FullStackName),
+		Description: pulumi.Sprintf("All deployed resources for the %s nitric stack", a.FullStackName),
 		ResourceQuery: &resourcegroups.GroupResourceQueryArgs{
 			Query: pulumi.Sprintf(`{
 				"ResourceTypeFilters":["AWS::AllSupported"],
 				"TagFilters":[{"Key":"%s"}]
-			}`, tags.GetResourceNameKey(a.stackId)),
+			}`, tags.GetResourceNameKey(a.StackId)),
 		},
 	})
 

--- a/cloud/aws/deploy/deploy.go
+++ b/cloud/aws/deploy/deploy.go
@@ -134,7 +134,7 @@ func (a *NitricAwsPulumiProvider) Pre(ctx *pulumi.Context, resources []*pulumix.
 	stackRandId, err := random.NewRandomString(ctx, fmt.Sprintf("%s-stack-name", ctx.Stack()), &random.RandomStringArgs{
 		Special: pulumi.Bool(false),
 		Length:  pulumi.Int(8),
-		Keepers: pulumi.ToMap(map[string]interface{}{
+		Keepers: pulumi.ToStringMap(map[string]string{
 			"stack-name": ctx.Stack(),
 		}),
 	})

--- a/cloud/aws/deploy/httpproxy.go
+++ b/cloud/aws/deploy/httpproxy.go
@@ -30,9 +30,9 @@ func (a *NitricAwsPulumiProvider) Http(ctx *pulumi.Context, parent pulumi.Resour
 	var err error
 	opts := []pulumi.ResourceOption{pulumi.Parent(parent)}
 
-	targetLambda := a.lambdas[http.Target.GetService()]
+	targetLambda := a.Lambdas[http.Target.GetService()]
 
-	httpProxyGatewayTags := common.Tags(a.stackId, name, resources.HttpProxy)
+	httpProxyGatewayTags := common.Tags(a.StackId, name, resources.HttpProxy)
 
 	doc := targetLambda.InvokeArn.ApplyT(func(invokeArn string) (string, error) {
 		spec := newApiSpec(name, invokeArn, httpProxyGatewayTags)
@@ -45,7 +45,7 @@ func (a *NitricAwsPulumiProvider) Http(ctx *pulumi.Context, parent pulumi.Resour
 		return string(b), nil
 	}).(pulumi.StringOutput)
 
-	a.httpProxies[name], err = apigatewayv2.NewApi(ctx, name, &apigatewayv2.ApiArgs{
+	a.HttpProxies[name], err = apigatewayv2.NewApi(ctx, name, &apigatewayv2.ApiArgs{
 		Body:           doc,
 		ProtocolType:   pulumi.String("HTTP"),
 		Tags:           pulumi.ToStringMap(httpProxyGatewayTags),
@@ -58,7 +58,7 @@ func (a *NitricAwsPulumiProvider) Http(ctx *pulumi.Context, parent pulumi.Resour
 	_, err = apigatewayv2.NewStage(ctx, name+"DefaultStage", &apigatewayv2.StageArgs{
 		AutoDeploy: pulumi.BoolPtr(true),
 		Name:       pulumi.String("$default"),
-		ApiId:      a.httpProxies[name].ID(),
+		ApiId:      a.HttpProxies[name].ID(),
 	}, opts...)
 	if err != nil {
 		return err
@@ -69,7 +69,7 @@ func (a *NitricAwsPulumiProvider) Http(ctx *pulumi.Context, parent pulumi.Resour
 		Function:  targetLambda.Name,
 		Action:    pulumi.String("lambda:InvokeFunction"),
 		Principal: pulumi.String("apigateway.amazonaws.com"),
-		SourceArn: pulumi.Sprintf("%s/*/*/*", a.httpProxies[name].ExecutionArn),
+		SourceArn: pulumi.Sprintf("%s/*/*/*", a.HttpProxies[name].ExecutionArn),
 	}, opts...)
 	if err != nil {
 		return err

--- a/cloud/aws/deploy/keyvalue.go
+++ b/cloud/aws/deploy/keyvalue.go
@@ -41,7 +41,7 @@ func (n *NitricAwsPulumiProvider) KeyValueStore(ctx *pulumi.Context, parent pulu
 	var err error
 	opts := []pulumi.ResourceOption{pulumi.Parent(parent)}
 
-	n.keyValueStores[name], err = dynamodb.NewTable(ctx, name, &dynamodb.TableArgs{
+	n.KeyValueStores[name], err = dynamodb.NewTable(ctx, name, &dynamodb.TableArgs{
 		Attributes: dynamodb.TableAttributeArray{
 			&dynamodb.TableAttributeArgs{
 				Name: pulumi.String("_pk"),
@@ -55,7 +55,7 @@ func (n *NitricAwsPulumiProvider) KeyValueStore(ctx *pulumi.Context, parent pulu
 		HashKey:     pulumi.String("_pk"),
 		RangeKey:    pulumi.String("_sk"),
 		BillingMode: pulumi.String("PAY_PER_REQUEST"),
-		Tags:        pulumi.ToStringMap(tags.Tags(n.stackId, name, resources.Collection)),
+		Tags:        pulumi.ToStringMap(tags.Tags(n.StackId, name, resources.Collection)),
 	}, opts...)
 
 	return err

--- a/cloud/aws/deploy/policy.go
+++ b/cloud/aws/deploy/policy.go
@@ -107,27 +107,27 @@ func actionsToAwsActions(actions []resourcespb.Action) []string {
 func (a *NitricAwsPulumiProvider) arnForResource(resource *deploymentspb.Resource) ([]interface{}, error) {
 	switch resource.Id.Type {
 	case resourcespb.ResourceType_Bucket:
-		if b, ok := a.buckets[resource.Id.Name]; ok {
+		if b, ok := a.Buckets[resource.Id.Name]; ok {
 			return []interface{}{b.Arn, pulumi.Sprintf("%s/*", b.Arn)}, nil
 		}
 	case resourcespb.ResourceType_Topic:
-		if t, ok := a.topics[resource.Id.Name]; ok {
+		if t, ok := a.Topics[resource.Id.Name]; ok {
 			return []interface{}{t.sns.Arn, t.sfn.Arn}, nil
 		}
 	case resourcespb.ResourceType_Queue:
-		if q, ok := a.queues[resource.Id.Name]; ok {
+		if q, ok := a.Queues[resource.Id.Name]; ok {
 			return []interface{}{q.Arn}, nil
 		}
 	case resourcespb.ResourceType_KeyValueStore:
-		if c, ok := a.keyValueStores[resource.Id.Name]; ok {
+		if c, ok := a.KeyValueStores[resource.Id.Name]; ok {
 			return []interface{}{c.Arn}, nil
 		}
 	case resourcespb.ResourceType_Secret:
-		if s, ok := a.secrets[resource.Id.Name]; ok {
+		if s, ok := a.Secrets[resource.Id.Name]; ok {
 			return []interface{}{s.Arn}, nil
 		}
 	case resourcespb.ResourceType_Websocket:
-		if w, ok := a.websockets[resource.Id.Name]; ok {
+		if w, ok := a.Websockets[resource.Id.Name]; ok {
 			return []interface{}{pulumi.Sprintf("%s/*", w.ExecutionArn)}, nil
 		}
 	default:
@@ -141,7 +141,7 @@ func (a *NitricAwsPulumiProvider) arnForResource(resource *deploymentspb.Resourc
 func (a *NitricAwsPulumiProvider) roleForPrincipal(resource *deploymentspb.Resource) (*iam.Role, error) {
 	switch resource.Id.Type {
 	case resourcespb.ResourceType_Service:
-		if f, ok := a.lambdaRoles[resource.Id.Name]; ok {
+		if f, ok := a.LambdaRoles[resource.Id.Name]; ok {
 			return f, nil
 		}
 	default:

--- a/cloud/aws/deploy/queue.go
+++ b/cloud/aws/deploy/queue.go
@@ -29,13 +29,13 @@ func (a *NitricAwsPulumiProvider) Queue(ctx *pulumi.Context, parent pulumi.Resou
 	opts := []pulumi.ResourceOption{pulumi.Parent(parent)}
 
 	queue, err := sqs.NewQueue(ctx, name, &sqs.QueueArgs{
-		Tags: pulumi.ToStringMap(common.Tags(a.stackId, name, resources.Queue)),
+		Tags: pulumi.ToStringMap(common.Tags(a.StackId, name, resources.Queue)),
 	}, opts...)
 	if err != nil {
 		return err
 	}
 
-	a.queues[name] = queue
+	a.Queues[name] = queue
 
 	return nil
 }

--- a/cloud/aws/deploy/runtime/runtime.go
+++ b/cloud/aws/deploy/runtime/runtime.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Nitric Technologies Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package runtime
 
 import _ "embed"

--- a/cloud/aws/deploy/runtime/runtime.go
+++ b/cloud/aws/deploy/runtime/runtime.go
@@ -1,0 +1,14 @@
+package runtime
+
+import _ "embed"
+
+// Embeds the runtime directly into the deploytime binary
+// This way the versions will always match as they're always built and versioned together (as a single artifact)
+// This should also help with docker build speeds as the runtime has already been "downloaded"
+//
+//go:embed runtime-aws
+var runtime []byte
+
+func NitricAwsRuntime() []byte {
+	return runtime
+}

--- a/cloud/aws/deploy/schedule.go
+++ b/cloud/aws/deploy/schedule.go
@@ -60,7 +60,7 @@ func (a *NitricAwsPulumiProvider) Schedule(ctx *pulumi.Context, parent pulumi.Re
 		return err
 	}
 
-	target, ok := a.lambdas[config.Target.GetService()]
+	target, ok := a.Lambdas[config.Target.GetService()]
 	if !ok {
 		return fmt.Errorf("unable to find target lambda: %s", config.Target.GetService())
 	}
@@ -76,7 +76,7 @@ func (a *NitricAwsPulumiProvider) Schedule(ctx *pulumi.Context, parent pulumi.Re
 	// Create a new eventbridge schedule
 	_, err = scheduler.NewSchedule(ctx, name, &scheduler.ScheduleArgs{
 		ScheduleExpression:         pulumi.String(awsScheduleExpression),
-		ScheduleExpressionTimezone: pulumi.String(a.config.ScheduleTimezone),
+		ScheduleExpressionTimezone: pulumi.String(a.AwsConfig.ScheduleTimezone),
 		FlexibleTimeWindow: &scheduler.ScheduleFlexibleTimeWindowArgs{
 			Mode: pulumi.String("OFF"),
 		},

--- a/cloud/aws/deploy/secret.go
+++ b/cloud/aws/deploy/secret.go
@@ -71,14 +71,14 @@ func createSecret(ctx *pulumi.Context, name string, tags map[string]string) (*se
 
 // Secret - Implements deployments of Nitric Secrets using AWS Secrets Manager
 func (a *NitricAwsPulumiProvider) Secret(ctx *pulumi.Context, parent pulumi.Resource, name string, config *deploymentspb.Secret) error {
-	awsTags := common.Tags(a.stackId, name, resources.Secret)
+	awsTags := common.Tags(a.StackId, name, resources.Secret)
 
 	var err error
 	var secret *secretsmanager.Secret
 
 	importArn := ""
-	if a.config.Import.Secrets != nil {
-		importArn = a.config.Import.Secrets[name]
+	if a.AwsConfig.Import.Secrets != nil {
+		importArn = a.AwsConfig.Import.Secrets[name]
 	}
 
 	if importArn != "" {
@@ -91,7 +91,7 @@ func (a *NitricAwsPulumiProvider) Secret(ctx *pulumi.Context, parent pulumi.Reso
 		return err
 	}
 
-	a.secrets[name] = secret
+	a.Secrets[name] = secret
 
 	return nil
 }

--- a/cloud/aws/deploy/secret.go
+++ b/cloud/aws/deploy/secret.go
@@ -82,7 +82,7 @@ func (a *NitricAwsPulumiProvider) Secret(ctx *pulumi.Context, parent pulumi.Reso
 	}
 
 	if importArn != "" {
-		secret, err = tagSecret(ctx, name, importArn, awsTags, a.resourceTaggingClient)
+		secret, err = tagSecret(ctx, name, importArn, awsTags, a.ResourceTaggingClient)
 	} else {
 		secret, err = createSecret(ctx, name, awsTags)
 	}

--- a/cloud/aws/deploy/service.go
+++ b/cloud/aws/deploy/service.go
@@ -259,7 +259,7 @@ func (a *NitricAwsPulumiProvider) Service(ctx *pulumi.Context, parent pulumi.Res
 		})
 
 		err := retry.Do(func() error {
-			_, err := a.lambdaClient.Invoke(&lambda.InvokeInput{
+			_, err := a.LambdaClient.Invoke(&lambda.InvokeInput{
 				FunctionName: aws.String(arn),
 				Payload:      payload,
 			})

--- a/cloud/aws/deploy/websocket.go
+++ b/cloud/aws/deploy/websocket.go
@@ -29,15 +29,15 @@ import (
 )
 
 func (a *NitricAwsPulumiProvider) Websocket(ctx *pulumi.Context, parent pulumi.Resource, name string, config *deploymentspb.Websocket) error {
-	defaultTarget := a.lambdas[config.MessageTarget.GetService()]
-	connectTarget := a.lambdas[config.ConnectTarget.GetService()]
-	disconnectTarget := a.lambdas[config.DisconnectTarget.GetService()]
+	defaultTarget := a.Lambdas[config.MessageTarget.GetService()]
+	connectTarget := a.Lambdas[config.ConnectTarget.GetService()]
+	disconnectTarget := a.Lambdas[config.DisconnectTarget.GetService()]
 
 	opts := []pulumi.ResourceOption{pulumi.Parent(parent)}
 
 	websocketApi, err := apigatewayv2.NewApi(ctx, name, &apigatewayv2.ApiArgs{
 		ProtocolType: pulumi.String("WEBSOCKET"),
-		Tags:         pulumi.ToStringMap(tags.Tags(a.stackId, name, resources.Websocket)),
+		Tags:         pulumi.ToStringMap(tags.Tags(a.StackId, name, resources.Websocket)),
 		// This isn't used (see AWS docs), but it is required. Instead we use the $default route
 		RouteSelectionExpression: pulumi.String("$request.body.action"),
 	}, opts...)
@@ -45,7 +45,7 @@ func (a *NitricAwsPulumiProvider) Websocket(ctx *pulumi.Context, parent pulumi.R
 		return err
 	}
 
-	a.websockets[name] = websocketApi
+	a.Websockets[name] = websocketApi
 
 	// Create the API integrations
 	integrationDefault, err := apigatewayv2.NewIntegration(ctx, fmt.Sprintf("%s-default-integration", name), &apigatewayv2.IntegrationArgs{
@@ -148,7 +148,7 @@ func (a *NitricAwsPulumiProvider) Websocket(ctx *pulumi.Context, parent pulumi.R
 		AutoDeploy: pulumi.BoolPtr(true),
 		Name:       pulumi.String(common.DefaultWsStageName),
 		ApiId:      websocketApi.ID(),
-		Tags:       pulumi.ToStringMap(tags.Tags(a.stackId, name+"DefaultStage", resources.Websocket)),
+		Tags:       pulumi.ToStringMap(tags.Tags(a.StackId, name+"DefaultStage", resources.Websocket)),
 	}, opts...)
 	if err != nil {
 		return err

--- a/cloud/azure/Makefile
+++ b/cloud/azure/Makefile
@@ -17,12 +17,12 @@ runtimebin:
 	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/runtime-azure -ldflags="-s -w -extldflags=-static" ./cmd/runtime
 
 predeploybin: runtimebin
-	@cp bin/runtime-azure deploy/runtime-azure
+	@cp bin/runtime-azure deploy/runtime/runtime-azure
 
 deploybin: predeploybin
 	@echo Building Azure Deployment Server
 	@CGO_ENABLED=0 go build -o bin/deploy-azure -ldflags="-s -w -extldflags=-static" -ldflags="-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=ignore" ./cmd/deploy
-	@rm deploy/runtime-azure
+	@rm deploy/runtime/runtime-azure
 
 .PHONY: install
 install: deploybin

--- a/cloud/azure/Makefile
+++ b/cloud/azure/Makefile
@@ -8,9 +8,9 @@ GOLANGCI_LINT ?= GOLANGCI_LINT_CACHE=$(GOLANGCI_LINT_CACHE) go run github.com/go
 binaries: deploybin
 
 sec:
-	@touch deploy/runtime-azure
+	@touch deploy/runtime/runtime-azure
 	@go run github.com/securego/gosec/v2/cmd/gosec@latest -exclude-dir=tools ./...
-	@rm deploy/runtime-azure
+	@rm deploy/runtime/runtime-azure
 
 runtimebin:
 	@echo Building Azure Runtime Server

--- a/cloud/azure/Makefile
+++ b/cloud/azure/Makefile
@@ -39,15 +39,15 @@ sourcefiles := $(shell find . -type f -name "*.go" -o -name "*.dockerfile")
 
 fmt:
 	@go run github.com/google/addlicense -c "Nitric Technologies Pty Ltd." -y "2021" $(sourcefiles)
-	@touch deploy/runtime-azure
+	@touch deploy/runtime/runtime-azure
 	$(GOLANGCI_LINT) run --fix
-	@rm deploy/runtime-azure
+	@rm deploy/runtime/runtime-azure
 
 lint:
 	@go run github.com/google/addlicense -check -c "Nitric Technologies Pty Ltd." -y "2021" $(sourcefiles)
-	@touch deploy/runtime-azure
+	@touch deploy/runtime/runtime-azure
 	$(GOLANGCI_LINT) run
-	@rm deploy/runtime-azure
+	@rm deploy/runtime/runtime-azure
 
 test: generate-mocks
 	@echo Running unit tests

--- a/cloud/azure/cmd/deploy/main.go
+++ b/cloud/azure/cmd/deploy/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/nitrictech/nitric/cloud/azure/deploy"
+	"github.com/nitrictech/nitric/cloud/azure/deploy/runtime"
 	"github.com/nitrictech/nitric/cloud/common/deploy/provider"
 )
 
@@ -25,7 +26,7 @@ import (
 func main() {
 	azureStack := deploy.NewNitricAzurePulumiProvider()
 
-	providerServer := provider.NewPulumiProviderServer(azureStack)
+	providerServer := provider.NewPulumiProviderServer(azureStack, runtime.NitricAzureRuntime)
 
 	providerServer.Start()
 }

--- a/cloud/azure/deploy/bucket.go
+++ b/cloud/azure/deploy/bucket.go
@@ -42,12 +42,12 @@ func removeWildcard(prefixFilter string) string {
 }
 
 func (p *NitricAzurePulumiProvider) newAzureBucketNotification(ctx *pulumi.Context, parent pulumi.Resource, bucketName string, config *deploymentspb.BucketListener) error {
-	target, ok := p.containerApps[config.GetService()]
+	target, ok := p.ContainerApps[config.GetService()]
 	if !ok {
 		return fmt.Errorf("target container app %s not found", config.GetService())
 	}
 
-	bucket, ok := p.buckets[bucketName]
+	bucket, ok := p.Buckets[bucketName]
 	if !ok {
 		return fmt.Errorf("target bucket %s not found", bucketName)
 	}
@@ -60,7 +60,7 @@ func (p *NitricAzurePulumiProvider) newAzureBucketNotification(ctx *pulumi.Conte
 	}
 
 	_, err = pulumiEventgrid.NewEventSubscription(ctx, ResourceName(ctx, bucketName+target.Name, EventSubscriptionRT), &pulumiEventgrid.EventSubscriptionArgs{
-		Scope: p.storageAccount.ID(),
+		Scope: p.StorageAccount.ID(),
 		WebhookEndpoint: pulumiEventgrid.EventSubscriptionWebhookEndpointArgs{
 			Url: pulumi.Sprintf("%s/%s/x-nitric-notification/bucket/%s", hostUrl, target.EventToken, bucketName),
 			// Only send one event per batch to avoid a single failure nacking multiple events.
@@ -88,9 +88,9 @@ func (p *NitricAzurePulumiProvider) Bucket(ctx *pulumi.Context, parent pulumi.Re
 	var err error
 	opts := []pulumi.ResourceOption{pulumi.Parent(parent)}
 
-	p.buckets[name], err = storage.NewBlobContainer(ctx, ResourceName(ctx, name, StorageContainerRT), &storage.BlobContainerArgs{
-		ResourceGroupName: p.resourceGroup.Name,
-		AccountName:       p.storageAccount.Name,
+	p.Buckets[name], err = storage.NewBlobContainer(ctx, ResourceName(ctx, name, StorageContainerRT), &storage.BlobContainerArgs{
+		ResourceGroupName: p.ResourceGroup.Name,
+		AccountName:       p.StorageAccount.Name,
 	}, opts...)
 	if err != nil {
 		return err

--- a/cloud/azure/deploy/deploy.go
+++ b/cloud/azure/deploy/deploy.go
@@ -24,10 +24,10 @@ import (
 
 	"github.com/nitrictech/nitric/cloud/common/deploy"
 	"github.com/nitrictech/nitric/cloud/common/deploy/provider"
+	"github.com/nitrictech/nitric/cloud/common/deploy/pulumix"
 	commonresources "github.com/nitrictech/nitric/cloud/common/deploy/resources"
 	"github.com/nitrictech/nitric/cloud/common/deploy/tags"
 	"github.com/nitrictech/nitric/core/pkg/logger"
-	deploymentspb "github.com/nitrictech/nitric/core/pkg/proto/deployments/v1"
 	resourcespb "github.com/nitrictech/nitric/core/pkg/proto/resources/v1"
 	"github.com/pkg/errors"
 	apimanagement "github.com/pulumi/pulumi-azure-native-sdk/apimanagement/v20201201"
@@ -53,7 +53,7 @@ type NitricAzurePulumiProvider struct {
 	ProjectName   string
 	StackName     string
 	FullStackName string
-	resources     []*deploymentspb.Resource
+	resources     []*pulumix.NitricPulumiResource[any]
 
 	AzureConfig *AzureConfig
 	Region      string
@@ -183,9 +183,9 @@ func createStorageAccount(ctx *pulumi.Context, group *resources.ResourceGroup, t
 	return storageAccount, nil
 }
 
-func hasResourceType(resources []*deploymentspb.Resource, resourceType resourcespb.ResourceType) bool {
+func hasResourceType(resources []*pulumix.NitricPulumiResource[any], resourceType resourcespb.ResourceType) bool {
 	for _, r := range resources {
-		if r.GetId().GetType() == resourceType {
+		if r.Id.GetType() == resourceType {
 			return true
 		}
 	}
@@ -193,7 +193,7 @@ func hasResourceType(resources []*deploymentspb.Resource, resourceType resources
 	return false
 }
 
-func (a *NitricAzurePulumiProvider) Pre(ctx *pulumi.Context, nitricResources []*deploymentspb.Resource) error {
+func (a *NitricAzurePulumiProvider) Pre(ctx *pulumi.Context, nitricResources []*pulumix.NitricPulumiResource[any]) error {
 	a.resources = nitricResources
 
 	// make our random stackId

--- a/cloud/azure/deploy/deploy.go
+++ b/cloud/azure/deploy/deploy.go
@@ -49,14 +49,12 @@ type ApiResources struct {
 }
 
 type NitricAzurePulumiProvider struct {
-	StackId       string
-	ProjectName   string
-	StackName     string
-	FullStackName string
-	resources     []*pulumix.NitricPulumiResource[any]
+	*deploy.CommonStackDetails
+
+	StackId   string
+	resources []*pulumix.NitricPulumiResource[any]
 
 	AzureConfig *AzureConfig
-	Region      string
 
 	ClientConfig *authorization.GetClientConfigResult
 
@@ -103,38 +101,15 @@ func (a *NitricAzurePulumiProvider) Config() (auto.ConfigMap, error) {
 func (a *NitricAzurePulumiProvider) Init(attributes map[string]interface{}) error {
 	var err error
 
-	region, ok := attributes["region"].(string)
-	if !ok {
-		return fmt.Errorf("Missing region attribute")
+	a.CommonStackDetails, err = deploy.CommonStackDetailsFromAttributes(attributes)
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, err.Error())
 	}
-
-	a.Region = region
 
 	a.AzureConfig, err = ConfigFromAttributes(attributes)
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "Bad stack configuration: %s", err)
 	}
-
-	var isString bool
-
-	iProject, hasProject := attributes["project"]
-	a.ProjectName, isString = iProject.(string)
-	if !hasProject || !isString || a.ProjectName == "" {
-		// need a valid project name
-		return fmt.Errorf("project is not set or invalid")
-	}
-
-	iStack, hasStack := attributes["stack"]
-	a.StackName, isString = iStack.(string)
-	if !hasStack || !isString || a.StackName == "" {
-		// need a valid stack name
-		return fmt.Errorf("stack is not set or invalid")
-	}
-
-	// Backwards compatible stack name
-	// The existing providers in the CLI
-	// Use the combined project and stack name
-	a.FullStackName = fmt.Sprintf("%s-%s", a.ProjectName, a.StackName)
 
 	return nil
 }

--- a/cloud/azure/deploy/deploy.go
+++ b/cloud/azure/deploy/deploy.go
@@ -43,9 +43,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-//go:embed runtime-azure
-var runtime []byte
-
 type ApiResources struct {
 	ApiManagementService *apimanagement.ApiManagementService
 	Api                  *apimanagement.Api

--- a/cloud/azure/deploy/keyvalue.go
+++ b/cloud/azure/deploy/keyvalue.go
@@ -24,9 +24,9 @@ func (p *NitricAzurePulumiProvider) KeyValueStore(ctx *pulumi.Context, parent pu
 	var err error
 	opts := []pulumi.ResourceOption{pulumi.Parent(parent)}
 
-	p.keyValueStores[name], err = storage.NewTable(ctx, name, &storage.TableArgs{
-		AccountName:       p.storageAccount.Name,
-		ResourceGroupName: p.resourceGroup.Name,
+	p.KeyValueStores[name], err = storage.NewTable(ctx, name, &storage.TableArgs{
+		AccountName:       p.StorageAccount.Name,
+		ResourceGroupName: p.ResourceGroup.Name,
 		TableName:         pulumi.String(name),
 	}, opts...)
 

--- a/cloud/azure/deploy/policy.go
+++ b/cloud/azure/deploy/policy.go
@@ -59,7 +59,7 @@ type resourceScope struct {
 func (p *NitricAzurePulumiProvider) scopeFromResource(resource *deploymentspb.Resource) (*resourceScope, error) {
 	switch resource.Id.Type {
 	case resourcespb.ResourceType_Topic:
-		topic, ok := p.topics[resource.Id.Name]
+		topic, ok := p.Topics[resource.Id.Name]
 		if !ok {
 			return nil, fmt.Errorf("topic %s not found", resource.Id.Name)
 		}
@@ -67,13 +67,13 @@ func (p *NitricAzurePulumiProvider) scopeFromResource(resource *deploymentspb.Re
 		return &resourceScope{
 			scope: pulumi.Sprintf(
 				"subscriptions/%s/resourceGroups/%s/providers/Microsoft.EventGrid/topics/%s",
-				p.clientConfig.SubscriptionId,
-				p.resourceGroup.Name,
+				p.ClientConfig.SubscriptionId,
+				p.ResourceGroup.Name,
 				topic.Name,
 			),
 		}, nil
 	case resourcespb.ResourceType_KeyValueStore:
-		kv, ok := p.keyValueStores[resource.Id.Name]
+		kv, ok := p.KeyValueStores[resource.Id.Name]
 		if !ok {
 			return nil, fmt.Errorf("key value store %s not found", resource.Id.Name)
 		}
@@ -81,14 +81,14 @@ func (p *NitricAzurePulumiProvider) scopeFromResource(resource *deploymentspb.Re
 		return &resourceScope{
 			scope: pulumi.Sprintf(
 				"subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/tableServices/default/tables/%s",
-				p.clientConfig.SubscriptionId,
-				p.resourceGroup.Name,
-				p.storageAccount.Name,
+				p.ClientConfig.SubscriptionId,
+				p.ResourceGroup.Name,
+				p.StorageAccount.Name,
 				kv.Name,
 			),
 		}, nil
 	case resourcespb.ResourceType_Bucket:
-		bucket, ok := p.buckets[resource.Id.Name]
+		bucket, ok := p.Buckets[resource.Id.Name]
 		if !ok {
 			return nil, fmt.Errorf("bucket %s not found", resource.Id.Name)
 		}
@@ -102,14 +102,14 @@ func (p *NitricAzurePulumiProvider) scopeFromResource(resource *deploymentspb.Re
 		return &resourceScope{
 			scope: pulumi.Sprintf(
 				"subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/blobServices/default/containers/%s",
-				p.clientConfig.SubscriptionId,
-				p.resourceGroup.Name,
-				p.storageAccount.Name,
+				p.ClientConfig.SubscriptionId,
+				p.ResourceGroup.Name,
+				p.StorageAccount.Name,
 				bucket.Name,
 			),
 		}, nil
 	case resourcespb.ResourceType_Queue:
-		queue, ok := p.queues[resource.Id.Name]
+		queue, ok := p.Queues[resource.Id.Name]
 		if !ok {
 			return nil, fmt.Errorf("queue %s not found", resource.Id.Name)
 		}
@@ -117,23 +117,23 @@ func (p *NitricAzurePulumiProvider) scopeFromResource(resource *deploymentspb.Re
 		return &resourceScope{
 			scope: pulumi.Sprintf(
 				"subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/queueServices/default/queues/%s",
-				p.clientConfig.SubscriptionId,
-				p.resourceGroup.Name,
-				p.storageAccount.Name,
+				p.ClientConfig.SubscriptionId,
+				p.ResourceGroup.Name,
+				p.StorageAccount.Name,
 				queue.Name,
 			),
 		}, nil
 	case resourcespb.ResourceType_Secret:
-		if p.keyVault == nil {
+		if p.KeyVault == nil {
 			return nil, fmt.Errorf("secret %s not found", resource.Id.Name)
 		}
 
 		return &resourceScope{
 			scope: pulumi.Sprintf(
 				"subscriptions/%s/resourcegroups/%s/providers/Microsoft.KeyVault/vaults/%s/secrets/%s",
-				p.clientConfig.SubscriptionId,
-				p.resourceGroup.Name,
-				p.keyVault.Name,
+				p.ClientConfig.SubscriptionId,
+				p.ResourceGroup.Name,
+				p.KeyVault.Name,
 				resource.Id.Name,
 			),
 			// condition: pulumi.Sprintf("@Resource[Microsoft.KeyVault/vaults/secrets].name equals %s'", resource.Name),
@@ -149,12 +149,12 @@ func (p *NitricAzurePulumiProvider) Policy(ctx *pulumi.Context, parent pulumi.Re
 	for _, resource := range policy.Resources {
 		for _, principal := range policy.Principals {
 			// The roles we need to assign
-			roles := actionsToAzureRoleDefinitions(p.roles.RoleDefinitions, policy.Actions)
+			roles := actionsToAzureRoleDefinitions(p.Roles.RoleDefinitions, policy.Actions)
 			if len(roles) == 0 {
-				return fmt.Errorf("policy contained not assignable actions %+v, %+v", policy, p.roles.RoleDefinitions)
+				return fmt.Errorf("policy contained not assignable actions %+v, %+v", policy, p.Roles.RoleDefinitions)
 			}
 
-			sp, ok := p.principals[principal.Id.Type][principal.Id.Name]
+			sp, ok := p.Principals[principal.Id.Type][principal.Id.Name]
 			if !ok {
 				return fmt.Errorf("principal %s of type %s not found", principal.Id.Name, principal.Id.Type)
 			}

--- a/cloud/azure/deploy/queue.go
+++ b/cloud/azure/deploy/queue.go
@@ -10,9 +10,9 @@ func (a *NitricAzurePulumiProvider) Queue(ctx *pulumi.Context, parent pulumi.Res
 	var err error
 	opts := []pulumi.ResourceOption{pulumi.Parent(parent)}
 
-	a.queues[name], err = storage.NewQueue(ctx, ResourceName(ctx, name, StorageQueueRT), &storage.QueueArgs{
-		AccountName:       a.storageAccount.Name,
-		ResourceGroupName: a.resourceGroup.Name,
+	a.Queues[name], err = storage.NewQueue(ctx, ResourceName(ctx, name, StorageQueueRT), &storage.QueueArgs{
+		AccountName:       a.StorageAccount.Name,
+		ResourceGroupName: a.ResourceGroup.Name,
 	}, opts...)
 
 	return err

--- a/cloud/azure/deploy/runtime/runtime.go
+++ b/cloud/azure/deploy/runtime/runtime.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Nitric Technologies Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package runtime
 
 import _ "embed"

--- a/cloud/azure/deploy/runtime/runtime.go
+++ b/cloud/azure/deploy/runtime/runtime.go
@@ -1,0 +1,14 @@
+package runtime
+
+import _ "embed"
+
+// Embeds the runtime directly into the deploytime binary
+// This way the versions will always match as they're always built and versioned together (as a single artifact)
+// This should also help with docker build speeds as the runtime has already been "downloaded"
+//
+//go:embed runtime-azure
+var runtime []byte
+
+func NitricAzureRuntime() []byte {
+	return runtime
+}

--- a/cloud/azure/deploy/schedule.go
+++ b/cloud/azure/deploy/schedule.go
@@ -42,7 +42,7 @@ func (p *NitricAzurePulumiProvider) Schedule(ctx *pulumi.Context, parent pulumi.
 	var err error
 	opts := []pulumi.ResourceOption{pulumi.Parent(parent)}
 
-	target := p.containerApps[config.GetTarget().GetService()]
+	target := p.ContainerApps[config.GetTarget().GetService()]
 
 	normalizedName := strings.ToLower(strings.ReplaceAll(name, " ", "-"))
 	cronExpression := ""
@@ -73,8 +73,8 @@ func (p *NitricAzurePulumiProvider) Schedule(ctx *pulumi.Context, parent pulumi.
 	}
 
 	_, err = app.NewDaprComponent(ctx, normalizedName, &app.DaprComponentArgs{
-		ResourceGroupName: p.resourceGroup.Name,
-		EnvironmentName:   p.containerEnv.ManagedEnv.Name,
+		ResourceGroupName: p.ResourceGroup.Name,
+		EnvironmentName:   p.ContainerEnv.ManagedEnv.Name,
 		ComponentName:     pulumi.String(normalizedName),
 		ComponentType:     pulumi.String("bindings.cron"),
 		Version:           pulumi.String("v1"),

--- a/cloud/azure/deploy/service.go
+++ b/cloud/azure/deploy/service.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/nitrictech/nitric/cloud/azure/runtime/resource"
 	"github.com/nitrictech/nitric/cloud/common/deploy/image"
+	"github.com/nitrictech/nitric/cloud/common/deploy/provider"
 	"github.com/nitrictech/nitric/cloud/common/deploy/resources"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/eventgrid/eventgrid"
@@ -147,7 +148,7 @@ var RoleDefinitions = map[string]string{
 	"TagContributor": "4a9ae827-6dc8-4573-8ac7-8239d42aa03f",
 }
 
-func (p *NitricAzurePulumiProvider) Service(ctx *pulumi.Context, parent pulumi.Resource, name string, service *deploymentspb.Service) error {
+func (p *NitricAzurePulumiProvider) Service(ctx *pulumi.Context, parent pulumi.Resource, name string, service *deploymentspb.Service, runtime provider.RuntimeProvider) error {
 	opts := []pulumi.ResourceOption{pulumi.Parent(parent)}
 
 	res := &ContainerApp{
@@ -167,7 +168,7 @@ func (p *NitricAzurePulumiProvider) Service(ctx *pulumi.Context, parent pulumi.R
 		Username:      p.containerEnv.RegistryUser.Elem(),
 		Password:      p.containerEnv.RegistryPass.Elem(),
 		Server:        p.containerEnv.Registry.LoginServer,
-		Runtime:       runtime,
+		Runtime:       runtime(),
 	}, opts...)
 	if err != nil {
 		return err

--- a/cloud/azure/deploy/service.go
+++ b/cloud/azure/deploy/service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nitrictech/nitric/cloud/azure/runtime/resource"
 	"github.com/nitrictech/nitric/cloud/common/deploy/image"
 	"github.com/nitrictech/nitric/cloud/common/deploy/provider"
+	"github.com/nitrictech/nitric/cloud/common/deploy/pulumix"
 	"github.com/nitrictech/nitric/cloud/common/deploy/resources"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/eventgrid/eventgrid"
@@ -37,7 +38,6 @@ import (
 
 	common "github.com/nitrictech/nitric/cloud/common/deploy/tags"
 	deploy "github.com/nitrictech/nitric/core/pkg/proto/deployments/v1"
-	deploymentspb "github.com/nitrictech/nitric/core/pkg/proto/deployments/v1"
 	resourcespb "github.com/nitrictech/nitric/core/pkg/proto/resources/v1"
 )
 
@@ -148,7 +148,7 @@ var RoleDefinitions = map[string]string{
 	"TagContributor": "4a9ae827-6dc8-4573-8ac7-8239d42aa03f",
 }
 
-func (p *NitricAzurePulumiProvider) Service(ctx *pulumi.Context, parent pulumi.Resource, name string, service *deploymentspb.Service, runtime provider.RuntimeProvider) error {
+func (p *NitricAzurePulumiProvider) Service(ctx *pulumi.Context, parent pulumi.Resource, name string, service *pulumix.NitricPulumiServiceConfig, runtime provider.RuntimeProvider) error {
 	opts := []pulumi.ResourceOption{pulumi.Parent(parent)}
 
 	res := &ContainerApp{
@@ -273,10 +273,10 @@ func (p *NitricAzurePulumiProvider) Service(ctx *pulumi.Context, parent pulumi.R
 		// },
 	}
 
-	for k, v := range service.Env {
+	for k, v := range service.Env() {
 		env = append(env, app.EnvironmentVarArgs{
 			Name:  pulumi.String(k),
-			Value: pulumi.String(v),
+			Value: v,
 		})
 	}
 

--- a/cloud/azure/deploy/topic.go
+++ b/cloud/azure/deploy/topic.go
@@ -43,12 +43,12 @@ type AzureEventGridTopicArgs struct {
 func (p *NitricAzurePulumiProvider) newEventGridTopicSubscription(ctx *pulumi.Context, parent pulumi.Resource, topicName string, config *deploymentspb.SubscriptionTarget) error {
 	opts := []pulumi.ResourceOption{pulumi.Parent(parent)}
 
-	target, ok := p.containerApps[config.GetService()]
+	target, ok := p.ContainerApps[config.GetService()]
 	if !ok {
 		return fmt.Errorf("Unable to find container app for service: %s", config.GetService())
 	}
 
-	topic, ok := p.topics[topicName]
+	topic, ok := p.Topics[topicName]
 	if !ok {
 		return fmt.Errorf("Unable to find topic: %s", topicName)
 	}
@@ -82,10 +82,10 @@ func (p *NitricAzurePulumiProvider) Topic(ctx *pulumi.Context, parent pulumi.Res
 	var err error
 	opts := []pulumi.ResourceOption{pulumi.Parent(parent)}
 
-	p.topics[name], err = eventgrid.NewTopic(ctx, ResourceName(ctx, name, EventGridRT), &eventgrid.TopicArgs{
-		ResourceGroupName: p.resourceGroup.Name,
-		Location:          p.resourceGroup.Location,
-		Tags:              pulumi.ToStringMap(tags.Tags(p.stackId, name, nitricresources.Topic)),
+	p.Topics[name], err = eventgrid.NewTopic(ctx, ResourceName(ctx, name, EventGridRT), &eventgrid.TopicArgs{
+		ResourceGroupName: p.ResourceGroup.Name,
+		Location:          p.ResourceGroup.Location,
+		Tags:              pulumi.ToStringMap(tags.Tags(p.StackId, name, nitricresources.Topic)),
 	}, opts...)
 	if err != nil {
 		return err

--- a/cloud/common/deploy/attributes.go
+++ b/cloud/common/deploy/attributes.go
@@ -17,9 +17,9 @@ package deploy
 import "fmt"
 
 type CommonStackDetails struct {
-	Project       string
+	ProjectName   string
 	FullStackName string
-	Stack         string
+	StackName     string
 	Region        string
 }
 
@@ -51,9 +51,9 @@ func CommonStackDetailsFromAttributes(attributes map[string]interface{}) (*Commo
 	fullStackName := fmt.Sprintf("%s-%s", project, stack)
 
 	return &CommonStackDetails{
-		Project:       project,
+		ProjectName:   project,
 		FullStackName: fullStackName,
 		Region:        region,
-		Stack:         stack,
+		StackName:     stack,
 	}, nil
 }

--- a/cloud/common/deploy/provider/provider.go
+++ b/cloud/common/deploy/provider/provider.go
@@ -42,7 +42,7 @@ type NitricPulumiProvider interface {
 	// Bucket - Deploy a Storage Bucket
 	Bucket(ctx *pulumi.Context, parent pulumi.Resource, name string, config *deploymentspb.Bucket) error
 	// Service - Deploy an service (Service)
-	Service(ctx *pulumi.Context, parent pulumi.Resource, name string, config *deploymentspb.Service) error
+	Service(ctx *pulumi.Context, parent pulumi.Resource, name string, config *deploymentspb.Service, runtimeProvider RuntimeProvider) error
 	// Topic - Deploy a Pub/Sub Topic
 	Topic(ctx *pulumi.Context, parent pulumi.Resource, name string, config *deploymentspb.Topic) error
 	// Queue - Deploy a Queue

--- a/cloud/common/deploy/provider/provider.go
+++ b/cloud/common/deploy/provider/provider.go
@@ -27,7 +27,7 @@ type NitricPulumiProvider interface {
 	// Init - Initialize the provider with the given attributes, prior to any resource creation or Pulumi Context creation
 	Init(attributes map[string]interface{}) error
 	// Pre - Called prior to any resource creation, after the Pulumi Context has been established
-	Pre(ctx *pulumi.Context, resources []*deploymentspb.Resource) error
+	Pre(ctx *pulumi.Context, resources []*pulumix.NitricPulumiResource[any]) error
 	// Config - Return the Pulumi ConfigMap for the provider
 	Config() (auto.ConfigMap, error)
 

--- a/cloud/common/deploy/provider/provider.go
+++ b/cloud/common/deploy/provider/provider.go
@@ -15,6 +15,7 @@
 package provider
 
 import (
+	"github.com/nitrictech/nitric/cloud/common/deploy/pulumix"
 	deploymentspb "github.com/nitrictech/nitric/core/pkg/proto/deployments/v1"
 	resourcespb "github.com/nitrictech/nitric/core/pkg/proto/resources/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
@@ -42,7 +43,7 @@ type NitricPulumiProvider interface {
 	// Bucket - Deploy a Storage Bucket
 	Bucket(ctx *pulumi.Context, parent pulumi.Resource, name string, config *deploymentspb.Bucket) error
 	// Service - Deploy an service (Service)
-	Service(ctx *pulumi.Context, parent pulumi.Resource, name string, config *deploymentspb.Service, runtimeProvider RuntimeProvider) error
+	Service(ctx *pulumi.Context, parent pulumi.Resource, name string, config *pulumix.NitricPulumiServiceConfig, runtimeProvider RuntimeProvider) error
 	// Topic - Deploy a Pub/Sub Topic
 	Topic(ctx *pulumi.Context, parent pulumi.Resource, name string, config *deploymentspb.Topic) error
 	// Queue - Deploy a Queue

--- a/cloud/common/deploy/provider/pulumi.go
+++ b/cloud/common/deploy/provider/pulumi.go
@@ -80,7 +80,7 @@ func createPulumiProgramForNitricProvider(req *deploymentspb.DeploymentUpRequest
 		}
 
 		// Pre-deployment Hook, used for validation, extension, spec modification, etc.
-		err = nitricProvider.Pre(ctx, req.Spec.Resources)
+		err = nitricProvider.Pre(ctx, pulumiResources)
 		if err != nil {
 			return err
 		}

--- a/cloud/common/deploy/provider/runtime.go
+++ b/cloud/common/deploy/provider/runtime.go
@@ -1,0 +1,4 @@
+package provider
+
+// A function that returns the runtime for a nitric provider
+type RuntimeProvider func() []byte

--- a/cloud/common/deploy/provider/runtime.go
+++ b/cloud/common/deploy/provider/runtime.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Nitric Technologies Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package provider
 
 // A function that returns the runtime for a nitric provider

--- a/cloud/common/deploy/pulumix/resource.go
+++ b/cloud/common/deploy/pulumix/resource.go
@@ -1,0 +1,43 @@
+package pulumix
+
+import (
+	deploymentspb "github.com/nitrictech/nitric/core/pkg/proto/deployments/v1"
+	resourcespb "github.com/nitrictech/nitric/core/pkg/proto/resources/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+type NitricPulumiResource[T any] struct {
+	Id     *resourcespb.ResourceIdentifier
+	Config T
+}
+
+type NitricPulumiServiceResource = NitricPulumiResource[*NitricPulumiServiceConfig]
+
+type NitricPulumiServiceConfig struct {
+	*deploymentspb.Service
+
+	// Allow for pulumi strings to be used as service environment variables
+	env pulumi.StringMap
+}
+
+func (n *NitricPulumiServiceConfig) SetEnv(key string, value pulumi.StringInput) {
+	if n.env == nil {
+		n.env = pulumi.StringMap{}
+	}
+
+	n.env[key] = value
+}
+
+func (n *NitricPulumiServiceConfig) Env() pulumi.StringMap {
+	envMap := pulumi.StringMap{}
+
+	for k, v := range n.Service.GetEnv() {
+		envMap[k] = pulumi.String(v)
+	}
+
+	for k, v := range n.env {
+		envMap[k] = v
+	}
+
+	return envMap
+}

--- a/cloud/common/deploy/pulumix/resource.go
+++ b/cloud/common/deploy/pulumix/resource.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Nitric Technologies Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pulumix
 
 import (

--- a/cloud/gcp/Makefile
+++ b/cloud/gcp/Makefile
@@ -16,9 +16,9 @@ predeploybin: runtimebin
 	@cp bin/runtime-gcp deploy/runtime/runtime-gcp
 
 sec:
-	@touch deploy/runtime-gcp
+	@touch deploy/runtime/runtime-gcp
 	@go run github.com/securego/gosec/v2/cmd/gosec@latest -exclude-dir=tools ./...
-	@rm deploy/runtime-gcp
+	@rm deploy/runtime/runtime-gcp
 
 # There appears to be an old namespace conflict with the protobuf definitions
 deploybin: predeploybin

--- a/cloud/gcp/Makefile
+++ b/cloud/gcp/Makefile
@@ -37,15 +37,15 @@ sourcefiles := $(shell find . -type f -name "*.go" -o -name "*.dockerfile")
 
 fmt:
 	@go run github.com/google/addlicense -c "Nitric Technologies Pty Ltd." -y "2021" $(sourcefiles)
-	@touch deploy/runtime-gcp
+	@touch deploy/runtime/runtime-gcp
 	$(GOLANGCI_LINT) run --fix
-	@rm deploy/runtime-gcp
+	@rm deploy/runtime/runtime-gcp
 
 lint:
 	@go run github.com/google/addlicense -check -c "Nitric Technologies Pty Ltd." -y "2021" $(sourcefiles)
-	@touch deploy/runtime-gcp
+	@touch deploy/runtime/runtime-gcp
 	$(GOLANGCI_LINT) run
-	@rm deploy/runtime-gcp
+	@rm deploy/runtime/runtime-gcp
 
 license-check: runtimebin
 	@echo Checking GCP Membrane OSS Licenses

--- a/cloud/gcp/Makefile
+++ b/cloud/gcp/Makefile
@@ -13,7 +13,7 @@ runtimebin:
 	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/runtime-gcp -ldflags="-s -w -extldflags=-static" ./cmd/runtime
 
 predeploybin: runtimebin
-	@cp bin/runtime-gcp deploy/runtime-gcp
+	@cp bin/runtime-gcp deploy/runtime/runtime-gcp
 
 sec:
 	@touch deploy/runtime-gcp
@@ -24,7 +24,7 @@ sec:
 deploybin: predeploybin
 	@echo Building GCP Deployment Server
 	@CGO_ENABLED=0 go build -o bin/deploy-gcp -ldflags="-s -w -extldflags=-static" -ldflags="-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=ignore" ./cmd/deploy
-	@rm deploy/runtime-gcp
+	@rm deploy/runtime/runtime-gcp
 
 .PHONY: install
 install: deploybin

--- a/cloud/gcp/cmd/deploy/main.go
+++ b/cloud/gcp/cmd/deploy/main.go
@@ -19,13 +19,14 @@ package main
 import (
 	"github.com/nitrictech/nitric/cloud/common/deploy/provider"
 	"github.com/nitrictech/nitric/cloud/gcp/deploy"
+	"github.com/nitrictech/nitric/cloud/gcp/deploy/runtime"
 )
 
 // Start the deployment server
 func main() {
 	gcpStack := deploy.NewNitricGcpProvider()
 
-	providerServer := provider.NewPulumiProviderServer(gcpStack)
+	providerServer := provider.NewPulumiProviderServer(gcpStack, runtime.NitricGcpRuntime)
 
 	providerServer.Start()
 }

--- a/cloud/gcp/deploy/bucket.go
+++ b/cloud/gcp/deploy/bucket.go
@@ -33,10 +33,10 @@ func (p *NitricGcpPulumiProvider) Bucket(ctx *pulumi.Context, parent pulumi.Reso
 	var err error
 	opts := append([]pulumi.ResourceOption{}, pulumi.Parent(parent))
 
-	resourceLabels := common.Tags(p.stackId, name, resources.Bucket)
+	resourceLabels := common.Tags(p.StackId, name, resources.Bucket)
 
-	p.buckets[name], err = storage.NewBucket(ctx, name, &storage.BucketArgs{
-		Location: pulumi.String(p.region),
+	p.Buckets[name], err = storage.NewBucket(ctx, name, &storage.BucketArgs{
+		Location: pulumi.String(p.Region),
 		Labels:   pulumi.ToStringMap(resourceLabels),
 	}, p.WithDefaultResourceOptions(opts...)...)
 	if err != nil {
@@ -63,18 +63,18 @@ func (p *NitricGcpPulumiProvider) newCloudStorageNotification(ctx *pulumi.Contex
 	}
 
 	topic, err := pubsub.NewTopic(ctx, name+"-topic", &pubsub.TopicArgs{
-		Labels: pulumi.ToStringMap(common.Tags(p.stackId, name, resources.Bucket)),
+		Labels: pulumi.ToStringMap(common.Tags(p.StackId, name, resources.Bucket)),
 	}, opts...)
 	if err != nil {
 		return err
 	}
 
-	targetService, ok := p.cloudRunServices[listener.GetService()]
+	targetService, ok := p.CloudRunServices[listener.GetService()]
 	if !ok {
 		return fmt.Errorf("unable to find target service for bucket listener: %s", listener.GetService())
 	}
 
-	targetBucket, ok := p.buckets[bucketName]
+	targetBucket, ok := p.Buckets[bucketName]
 	if !ok {
 		return fmt.Errorf("unable to find target bucket for bucket listener: %s", bucketName)
 	}

--- a/cloud/gcp/deploy/deploy.go
+++ b/cloud/gcp/deploy/deploy.go
@@ -29,6 +29,7 @@ import (
 	"github.com/nitrictech/nitric/cloud/common/deploy"
 	"github.com/nitrictech/nitric/cloud/common/deploy/provider"
 	"github.com/nitrictech/nitric/cloud/common/deploy/pulumix"
+	deploymentspb "github.com/nitrictech/nitric/core/pkg/proto/deployments/v1"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/apigateway"
 	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/cloudtasks"
@@ -234,13 +235,13 @@ func (a *NitricGcpPulumiProvider) Pre(ctx *pulumi.Context, resources []*pulumix.
 	}
 
 	// Check if a key value store exists, if so get/create a (default) firestore database
-	kvStoreExists := lo.SomeBy(resources, func(res *deploymentspb.Resource) bool {
+	kvStoreExists := lo.SomeBy(resources, func(res *pulumix.NitricPulumiResource[any]) bool {
 		_, ok := res.Config.(*deploymentspb.Resource_KeyValueStore)
 		return ok
 	})
 
 	if kvStoreExists {
-		err := createFirestoreDatabase(ctx, *project.ProjectId, a.region)
+		err := createFirestoreDatabase(ctx, *project.ProjectId, a.Region)
 		if err != nil {
 			return err
 		}

--- a/cloud/gcp/deploy/deploy.go
+++ b/cloud/gcp/deploy/deploy.go
@@ -28,7 +28,7 @@ import (
 	"cloud.google.com/go/firestore/apiv1/admin/adminpb"
 	"github.com/nitrictech/nitric/cloud/common/deploy"
 	"github.com/nitrictech/nitric/cloud/common/deploy/provider"
-	deploymentspb "github.com/nitrictech/nitric/core/pkg/proto/deployments/v1"
+	"github.com/nitrictech/nitric/cloud/common/deploy/pulumix"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/apigateway"
 	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/cloudtasks"
@@ -163,7 +163,7 @@ var baseComputePermissions []string = []string{
 	"monitoring.timeSeries.create",
 }
 
-func (a *NitricGcpPulumiProvider) Pre(ctx *pulumi.Context, resources []*deploymentspb.Resource) error {
+func (a *NitricGcpPulumiProvider) Pre(ctx *pulumi.Context, resources []*pulumix.NitricPulumiResource[any]) error {
 	// make our random stackId
 	stackRandId, err := random.NewRandomString(ctx, fmt.Sprintf("%s-stack-name", ctx.Stack()), &random.RandomStringArgs{
 		Special: pulumi.Bool(false),

--- a/cloud/gcp/deploy/deploy.go
+++ b/cloud/gcp/deploy/deploy.go
@@ -75,13 +75,6 @@ type NitricGcpPulumiProvider struct {
 	provider.NitricDefaultOrder
 }
 
-// Embeds the runtime directly into the deploytime binary
-// This way the versions will always match as they're always built and versioned together (as a single artifact)
-// This should also help with docker build speeds as the runtime has already been "downloaded"
-//
-//go:embed runtime-gcp
-var runtime []byte
-
 var _ provider.NitricPulumiProvider = (*NitricGcpPulumiProvider)(nil)
 
 const pulumiGcpVersion = "6.67.0"

--- a/cloud/gcp/deploy/httpproxy.go
+++ b/cloud/gcp/deploy/httpproxy.go
@@ -35,9 +35,9 @@ import (
 func (p *NitricGcpPulumiProvider) Http(ctx *pulumi.Context, parent pulumi.Resource, name string, config *deploymentspb.Http) error {
 	opts := append([]pulumi.ResourceOption{}, pulumi.Parent(parent))
 
-	resourceLabels := common.Tags(p.stackId, name, resources.HttpProxy)
+	resourceLabels := common.Tags(p.StackId, name, resources.HttpProxy)
 
-	targetService := p.cloudRunServices[config.Target.GetService()]
+	targetService := p.CloudRunServices[config.Target.GetService()]
 
 	// normalise the name to match the required format
 	// ^projects/([a-z0-9-]+)/locations/([a-z0-9-]+)(/([a-z]+)/([a-z0-9-.]+))+$
@@ -70,7 +70,7 @@ func (p *NitricGcpPulumiProvider) Http(ctx *pulumi.Context, parent pulumi.Resour
 
 	// Deploy the config
 	apiConfig, err := apigateway.NewApiConfig(ctx, normalizedName+"-config", &apigateway.ApiConfigArgs{
-		Project:     pulumi.String(p.config.ProjectId),
+		Project:     pulumi.String(p.GcpConfig.ProjectId),
 		Api:         api.ApiId,
 		DisplayName: pulumi.String(normalizedName + "-config"),
 		OpenapiDocuments: apigateway.ApiConfigOpenapiDocumentArray{
@@ -94,10 +94,10 @@ func (p *NitricGcpPulumiProvider) Http(ctx *pulumi.Context, parent pulumi.Resour
 	}
 
 	// Deploy the gateway
-	p.httpProxies[name], err = apigateway.NewGateway(ctx, normalizedName+"-gateway", &apigateway.GatewayArgs{
+	p.HttpProxies[name], err = apigateway.NewGateway(ctx, normalizedName+"-gateway", &apigateway.GatewayArgs{
 		DisplayName: pulumi.String(normalizedName + "-gateway"),
 		GatewayId:   pulumi.String(normalizedName + "-gateway"),
-		ApiConfig:   pulumi.Sprintf("projects/%s/locations/global/apis/%s/configs/%s", p.config.ProjectId, api.ApiId, apiConfig.ApiConfigId),
+		ApiConfig:   pulumi.Sprintf("projects/%s/locations/global/apis/%s/configs/%s", p.GcpConfig.ProjectId, api.ApiId, apiConfig.ApiConfigId),
 		Labels:      pulumi.ToStringMap(resourceLabels),
 	}, p.WithDefaultResourceOptions(opts...)...)
 	if err != nil {

--- a/cloud/gcp/deploy/policy.go
+++ b/cloud/gcp/deploy/policy.go
@@ -159,7 +159,7 @@ func actionsToGcpActions(actions []v1.Action) []string {
 func (a *NitricGcpPulumiProvider) serviceAccountForPrincipal(resource *deploymentspb.Resource) (*serviceaccount.Account, error) {
 	switch resource.Id.Type {
 	case resourcespb.ResourceType_Service:
-		if f, ok := a.cloudRunServices[resource.Id.Name]; ok {
+		if f, ok := a.CloudRunServices[resource.Id.Name]; ok {
 			return f.ServiceAccount, nil
 		}
 	default:
@@ -190,7 +190,7 @@ func (p *NitricGcpPulumiProvider) Policy(ctx *pulumi.Context, parent pulumi.Reso
 
 			switch resource.Id.Type {
 			case v1.ResourceType_Bucket:
-				b := p.buckets[resource.Id.Name]
+				b := p.Buckets[resource.Id.Name]
 
 				_, err = gcpstorage.NewBucketIAMMember(ctx, memberName, &gcpstorage.BucketIAMMemberArgs{
 					Bucket: b.Name,
@@ -211,14 +211,14 @@ func (p *NitricGcpPulumiProvider) Policy(ctx *pulumi.Context, parent pulumi.Reso
 
 				_, err = projects.NewIAMMember(ctx, memberName, &projects.IAMMemberArgs{
 					Member:  memberId,
-					Project: pulumi.String(p.config.ProjectId),
+					Project: pulumi.String(p.GcpConfig.ProjectId),
 					Role:    collRole.Name,
 				}, opts...)
 				if err != nil {
 					return err
 				}
 			case v1.ResourceType_Topic:
-				t := p.topics[resource.Id.Name]
+				t := p.Topics[resource.Id.Name]
 
 				_, err = pubsub.NewTopicIAMMember(ctx, memberName, &pubsub.TopicIAMMemberArgs{
 					Topic:  t.Name,
@@ -229,7 +229,7 @@ func (p *NitricGcpPulumiProvider) Policy(ctx *pulumi.Context, parent pulumi.Reso
 					return err
 				}
 			case v1.ResourceType_Queue:
-				q := p.queues[resource.Id.Name]
+				q := p.Queues[resource.Id.Name]
 
 				_, err = pubsub.NewTopicIAMMember(ctx, memberName, &pubsub.TopicIAMMemberArgs{
 					Topic:  q.Name,
@@ -250,7 +250,7 @@ func (p *NitricGcpPulumiProvider) Policy(ctx *pulumi.Context, parent pulumi.Reso
 				}
 
 				if needSubConsume {
-					subscription := p.queueSubscriptions[resource.Id.Name]
+					subscription := p.QueueSubscriptions[resource.Id.Name]
 					subRolePolicy, err := NewCustomRole(ctx, name+"subscription", []string{"pubsub.subscriptions.consume"}, opts...)
 					if err != nil {
 						return err
@@ -266,7 +266,7 @@ func (p *NitricGcpPulumiProvider) Policy(ctx *pulumi.Context, parent pulumi.Reso
 					}
 				}
 			case v1.ResourceType_Secret:
-				s := p.secrets[resource.Id.Name]
+				s := p.Secrets[resource.Id.Name]
 
 				_, err = secretmanager.NewSecretIamMember(ctx, memberName, &secretmanager.SecretIamMemberArgs{
 					SecretId: s.SecretId,

--- a/cloud/gcp/deploy/queue.go
+++ b/cloud/gcp/deploy/queue.go
@@ -45,17 +45,17 @@ func (p *NitricGcpPulumiProvider) Queue(ctx *pulumi.Context, parent pulumi.Resou
 	var err error
 	opts := append([]pulumi.ResourceOption{}, pulumi.Parent(parent))
 
-	resourceLabels := common.Tags(p.stackId, name, resources.Queue)
+	resourceLabels := common.Tags(p.StackId, name, resources.Queue)
 
-	p.queues[name], err = pubsub.NewTopic(ctx, fmt.Sprintf("%s-queue", name), &pubsub.TopicArgs{
+	p.Queues[name], err = pubsub.NewTopic(ctx, fmt.Sprintf("%s-queue", name), &pubsub.TopicArgs{
 		Labels: pulumi.ToStringMap(resourceLabels),
 	}, p.WithDefaultResourceOptions(opts...)...)
 	if err != nil {
 		return err
 	}
 
-	p.queueSubscriptions[name], err = pubsub.NewSubscription(ctx, fmt.Sprintf("%s-nitricqueue", name), &pubsub.SubscriptionArgs{
-		Topic:  p.queues[name].Name,
+	p.QueueSubscriptions[name], err = pubsub.NewSubscription(ctx, fmt.Sprintf("%s-nitricqueue", name), &pubsub.SubscriptionArgs{
+		Topic:  p.Queues[name].Name,
 		Labels: pulumi.ToStringMap(resourceLabels),
 		ExpirationPolicy: &pubsub.SubscriptionExpirationPolicyArgs{
 			Ttl: pulumi.String(""),

--- a/cloud/gcp/deploy/runtime/runtime.go
+++ b/cloud/gcp/deploy/runtime/runtime.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Nitric Technologies Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package runtime
 
 import _ "embed"

--- a/cloud/gcp/deploy/runtime/runtime.go
+++ b/cloud/gcp/deploy/runtime/runtime.go
@@ -1,0 +1,14 @@
+package runtime
+
+import _ "embed"
+
+// Embeds the runtime directly into the deploytime binary
+// This way the versions will always match as they're always built and versioned together (as a single artifact)
+// This should also help with docker build speeds as the runtime has already been "downloaded"
+//
+//go:embed runtime-gcp
+var runtime []byte
+
+func NitricGcpRuntime() []byte {
+	return runtime
+}

--- a/cloud/gcp/deploy/schedule.go
+++ b/cloud/gcp/deploy/schedule.go
@@ -70,12 +70,12 @@ func (p *NitricGcpPulumiProvider) Schedule(ctx *pulumi.Context, parent pulumi.Re
 		return err
 	}
 
-	targetService := p.cloudRunServices[config.Target.GetService()]
+	targetService := p.CloudRunServices[config.Target.GetService()]
 
 	payload := base64.StdEncoding.EncodeToString(eventJSON)
 
 	_, err = cloudscheduler.NewJob(ctx, name, &cloudscheduler.JobArgs{
-		TimeZone: pulumi.String(p.config.ScheduleTimezone),
+		TimeZone: pulumi.String(p.GcpConfig.ScheduleTimezone),
 		HttpTarget: &cloudscheduler.JobHttpTargetArgs{
 			Uri: pulumi.Sprintf("%s/x-nitric-schedule/%s?token=%s", targetService.Url, name, targetService.EventToken),
 			OidcToken: &cloudscheduler.JobHttpTargetOidcTokenArgs{

--- a/cloud/gcp/deploy/secret.go
+++ b/cloud/gcp/deploy/secret.go
@@ -35,14 +35,14 @@ func (p *NitricGcpPulumiProvider) Secret(ctx *pulumi.Context, parent pulumi.Reso
 	var err error
 	opts := append([]pulumi.ResourceOption{}, pulumi.Parent(parent))
 
-	secId := pulumi.Sprintf("%s-%s", p.stackName, name)
+	secId := pulumi.Sprintf("%s-%s", p.StackName, name)
 
-	p.secrets[name], err = secretmanager.NewSecret(ctx, name, &secretmanager.SecretArgs{
+	p.Secrets[name], err = secretmanager.NewSecret(ctx, name, &secretmanager.SecretArgs{
 		Replication: secretmanager.SecretReplicationArgs{
 			Automatic: pulumi.Bool(true),
 		},
 		SecretId: secId,
-		Labels:   pulumi.ToStringMap(common.Tags(p.stackId, name, resources.Secret)),
+		Labels:   pulumi.ToStringMap(common.Tags(p.StackId, name, resources.Secret)),
 	}, p.WithDefaultResourceOptions(opts...)...)
 	if err != nil {
 		return err

--- a/cloud/gcp/deploy/service.go
+++ b/cloud/gcp/deploy/service.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/nitrictech/nitric/cloud/common/deploy/image"
 	"github.com/nitrictech/nitric/cloud/common/deploy/provider"
+	"github.com/nitrictech/nitric/cloud/common/deploy/pulumix"
 	"github.com/nitrictech/nitric/cloud/common/deploy/telemetry"
-	deploymentspb "github.com/nitrictech/nitric/core/pkg/proto/deployments/v1"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/cloudrun"
 	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/projects"
@@ -45,7 +45,7 @@ type NitricCloudRunService struct {
 	EventToken     pulumi.StringOutput
 }
 
-func (p *NitricGcpPulumiProvider) Service(ctx *pulumi.Context, parent pulumi.Resource, name string, config *deploymentspb.Service, runtime provider.RuntimeProvider) error {
+func (p *NitricGcpPulumiProvider) Service(ctx *pulumi.Context, parent pulumi.Resource, name string, config *pulumix.NitricPulumiServiceConfig, runtime provider.RuntimeProvider) error {
 	opts := []pulumi.ResourceOption{pulumi.Parent(parent)}
 
 	res := &NitricCloudRunService{
@@ -178,10 +178,10 @@ func (p *NitricGcpPulumiProvider) Service(ctx *pulumi.Context, parent pulumi.Res
 		})
 	}
 
-	for k, v := range config.Env {
+	for k, v := range config.Env() {
 		env = append(env, cloudrun.ServiceTemplateSpecContainerEnvArgs{
 			Name:  pulumi.String(k),
-			Value: pulumi.String(v),
+			Value: v,
 		})
 	}
 

--- a/cloud/gcp/deploy/service.go
+++ b/cloud/gcp/deploy/service.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/nitrictech/nitric/cloud/common/deploy/image"
+	"github.com/nitrictech/nitric/cloud/common/deploy/provider"
 	"github.com/nitrictech/nitric/cloud/common/deploy/telemetry"
 	deploymentspb "github.com/nitrictech/nitric/core/pkg/proto/deployments/v1"
 	"github.com/pkg/errors"
@@ -44,7 +45,7 @@ type NitricCloudRunService struct {
 	EventToken     pulumi.StringOutput
 }
 
-func (p *NitricGcpPulumiProvider) Service(ctx *pulumi.Context, parent pulumi.Resource, name string, config *deploymentspb.Service) error {
+func (p *NitricGcpPulumiProvider) Service(ctx *pulumi.Context, parent pulumi.Resource, name string, config *deploymentspb.Service, runtime provider.RuntimeProvider) error {
 	opts := []pulumi.ResourceOption{pulumi.Parent(parent)}
 
 	res := &NitricCloudRunService{
@@ -82,7 +83,7 @@ func (p *NitricGcpPulumiProvider) Service(ctx *pulumi.Context, parent pulumi.Res
 		Username:      pulumi.String("oauth2accesstoken"),
 		Password:      pulumi.String(p.authToken.AccessToken),
 		Server:        pulumi.String("https://gcr.io"),
-		Runtime:       runtime,
+		Runtime:       runtime(),
 		Telemetry: &telemetry.TelemetryConfigArgs{
 			TraceSampling:       unitConfig.Telemetry,
 			TraceName:           "googlecloud",

--- a/cloud/gcp/deploy/topic.go
+++ b/cloud/gcp/deploy/topic.go
@@ -36,18 +36,18 @@ func (p *NitricGcpPulumiProvider) Topic(ctx *pulumi.Context, parent pulumi.Resou
 	var err error
 	opts := append([]pulumi.ResourceOption{}, pulumi.Parent(parent))
 
-	p.topics[name], err = pubsub.NewTopic(ctx, name, &pubsub.TopicArgs{
-		Labels: pulumi.ToStringMap(common.Tags(p.stackId, name, resources.Topic)),
+	p.Topics[name], err = pubsub.NewTopic(ctx, name, &pubsub.TopicArgs{
+		Labels: pulumi.ToStringMap(common.Tags(p.StackId, name, resources.Topic)),
 	}, p.WithDefaultResourceOptions(opts...)...)
 	if err != nil {
 		return err
 	}
 
 	for _, sub := range config.Subscriptions {
-		targetService := p.cloudRunServices[sub.GetService()]
+		targetService := p.CloudRunServices[sub.GetService()]
 
 		_, err := pubsub.NewSubscription(ctx, GetSubName(targetService.Name, name), &pubsub.SubscriptionArgs{
-			Topic:              p.topics[name].Name, // The GCP topic name
+			Topic:              p.Topics[name].Name, // The GCP topic name
 			AckDeadlineSeconds: pulumi.Int(300),
 			RetryPolicy: pubsub.SubscriptionRetryPolicyArgs{
 				MinimumBackoff: pulumi.String("15s"),


### PR DESCRIPTION
This change is required to allow providers to be compiled into other code (reusable)