### PR TITLE
chore: spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 Apps built with Nitric can be deployed to AWS, Azure or Google Cloud all from the same code base so you can focus on your products, not your cloud provider.
 
-Nitric makes it easy to architect cloud applications directly in application code, building scalable & secure applications with least priviledge security out of the box.
+Nitric makes it easy to architect cloud applications directly in application code, building scalable & secure applications with least privilege security out of the box.
 
 <p align="center">
   <img alt="Nitric Diagram" src="docs/assets/diagram.svg">

--- a/cloud/common/deploy/config/config.go
+++ b/cloud/common/deploy/config/config.go
@@ -65,7 +65,7 @@ func ValidateRawConfigKeys(attributes map[string]interface{}, knownKeys []string
 	return nil
 }
 
-// ConfigFromAttributes - Merges given attributes into a useable config, all types are updated with the provided default config item
+// ConfigFromAttributes - Merges given attributes into a usable config, all types are updated with the provided default config item
 func ConfigFromAttributes[T AbstractItem](attributes map[string]interface{}, defaultItem T) (*AbstractConfig[T], error) {
 	config := new(AbstractConfig[T])
 

--- a/cloud/gcp/cmd/runtime/README.md
+++ b/cloud/gcp/cmd/runtime/README.md
@@ -33,5 +33,5 @@ Debian
 make gcp-docker-debian
 ```
 
-> __Note:__ Seperate distributions required between glibc/musl as dynamic linker is used for golang plugin support
+> __Note:__ Separate distributions required between glibc/musl as dynamic linker is used for golang plugin support
 

--- a/cloud/gcp/runtime/gateway/http_test.go
+++ b/cloud/gcp/runtime/gateway/http_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Http", func() {
 			})
 		})
 
-		When("From a subcription with a NitricEvent", func() {
+		When("From a subscription with a NitricEvent", func() {
 			content, _ := structpb.NewStruct(map[string]interface{}{
 				"Test": "Test",
 			})

--- a/core/contracts/validate/validate.proto
+++ b/core/contracts/validate/validate.proto
@@ -535,7 +535,7 @@ message StringRules {
     // at a maximum
     optional uint64 max_bytes = 5;
 
-    // Pattern specifes that this field must match against the specified
+    // Pattern specifies that this field must match against the specified
     // regular expression (RE2 syntax). The included expression should elide
     // any delimiters.
     optional string pattern  = 6;
@@ -647,7 +647,7 @@ message BytesRules {
     // at a maximum
     optional uint64 max_len = 3;
 
-    // Pattern specifes that this field must match against the specified
+    // Pattern specifies that this field must match against the specified
     // regular expression (RE2 syntax). The included expression should elide
     // any delimiters.
     optional string pattern  = 4;
@@ -733,11 +733,11 @@ message RepeatedRules {
     optional uint64 max_items = 2;
 
     // Unique specifies that all elements in this field must be unique. This
-    // contraint is only applicable to scalar and enum types (messages are not
+    // constraint is only applicable to scalar and enum types (messages are not
     // supported).
     optional bool   unique    = 3;
 
-    // Items specifies the contraints to be applied to each item in the field.
+    // Items specifies the constraints to be applied to each item in the field.
     // Repeated message fields will still execute validation against each item
     // unless skip is specified here.
     optional FieldRules items = 4;

--- a/core/pkg/proto/deployments/v1/deployments.pb.go
+++ b/core/pkg/proto/deployments/v1/deployments.pb.go
@@ -88,7 +88,7 @@ type ResourceDeploymentStatus int32
 const (
 	// The action hasn't started, usually due to a dependency
 	ResourceDeploymentStatus_PENDING ResourceDeploymentStatus = 0
-	// The action in currently in-flight, e.g. waiting for cloud provder to provision a resource
+	// The action in currently in-flight, e.g. waiting for cloud provider to provision a resource
 	ResourceDeploymentStatus_IN_PROGRESS ResourceDeploymentStatus = 1
 	// The action has been applied successfully
 	ResourceDeploymentStatus_SUCCESS ResourceDeploymentStatus = 2

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,6 +1,6 @@
 # Configuring the Membrane
 
-In most cases these will already be set as environment variables withing a nitric templates Dockerfile. This documentation is targeted at developers building their own nitric application templates and those who require the membrane to be run on a bare-metal server.
+In most cases these will already be set as environment variables within a nitric templates Dockerfile. This documentation is targeted at developers building their own nitric application templates and those who require the membrane to be run on a bare-metal server.
 
 ## Options
 

--- a/docs/Operating-Modes.md
+++ b/docs/Operating-Modes.md
@@ -1,6 +1,6 @@
 # Membrane Operating Modes
 
-The membrane operates in a number of different modes. These modes control how the membrane communicated with it's child process. The mode is configured by setting the system environment variable `MEMBRANE_MODE`. This environment variable will typically be implemented in nitric templates, based on their template type. Availabe modes are:
+The membrane operates in a number of different modes. These modes control how the membrane communicated with it's child process. The mode is configured by setting the system environment variable `MEMBRANE_MODE`. This environment variable will typically be implemented in nitric templates, based on their template type. Available modes are:
 
 * FaaS: `MEMBRANE_MODE="FAAS"`
 * HTTP Proxy: `MEMBRANE_MODE="HTTP_PROXY"`

--- a/nitric/proto/deployments/v1/deployments.proto
+++ b/nitric/proto/deployments/v1/deployments.proto
@@ -63,7 +63,7 @@ enum ResourceDeploymentAction {
 enum ResourceDeploymentStatus {
   // The action hasn't started, usually due to a dependency
   PENDING = 0;
-  // The action in currently in-flight, e.g. waiting for cloud provder to provision a resource
+  // The action in currently in-flight, e.g. waiting for cloud provider to provision a resource
   IN_PROGRESS = 1;
   // The action has been applied successfully
   SUCCESS = 2;


### PR DESCRIPTION
Shared this link with my coworkers and then noticed that privilege is
spelled wrong on the front page. Ran `codespell` on the
repo and fixed accordingly.

<!---
Thanks for your contribution! Please ensure that you have read the [Contribution guide](https://github.com/nitrictech/nitric/blob/main/CONTRIBUTING.md).
-->

# Description

Include a summary of the change or which issue is fixed. Please also include any relevant context including any dependencies that are required for this change.

Fixes spelling

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

I don't know for sure, but I _think_ this requires a documentation update

# Testing

Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

No code was updated, no tests were run.
