### PR TITLE
fix: Add env variable to worker timeout configuration.

### DIFF
--- a/cloud/common/deploy/image/image.go
+++ b/cloud/common/deploy/image/image.go
@@ -83,6 +83,7 @@ func NewImage(ctx *pulumi.Context, name string, args *ImageArgs, opts ...pulumi.
 	}
 
 	buildContext := fmt.Sprintf("%s/build-%s", os.TempDir(), name)
+	//#nosec G301 - Patch to remove exec perms
 	err = os.MkdirAll(buildContext, os.ModePerm)
 	if err != nil {
 		return nil, err

--- a/core/pkg/env/variables.go
+++ b/core/pkg/env/variables.go
@@ -18,6 +18,7 @@ package env
 var (
 	MAX_WORKERS     = GetEnv("MAX_WORKERS", "300")
 	MIN_WORKERS     = GetEnv("MIN_WORKERS", "1")
+	WORKER_TIMEOUT  = GetEnv("WORKER_TIMEOUT", "10")
 	SERVICE_ADDRESS = GetEnv("SERVICE_ADDRESS", "127.0.0.1:50051")
 	LOG_LEVEL       = GetEnv("LOG_LEVEL", "INFO")
 )

--- a/core/pkg/membrane/membrane.go
+++ b/core/pkg/membrane/membrane.go
@@ -296,8 +296,11 @@ func New(options *MembraneOptions) (*Membrane, error) {
 		return nil, err
 	}
 
+	workerTimeout, err := env.WORKER_TIMEOUT.Int()
 	if options.ChildTimeoutSeconds < 1 {
-		options.ChildTimeoutSeconds = 10
+		options.ChildTimeoutSeconds = workerTimeout
+	} else if err != nil {
+		return nil, err
 	}
 
 	if options.GatewayPlugin == nil {


### PR DESCRIPTION
Add WORKER_TIMEOUT to allow for the configuration of nitric gateway timeout when waiting for workers to connect.