### PR TITLE
fix: return an explicit error when duplicate resources are found

### DIFF
--- a/cloud/aws/runtime/resource/resource.go
+++ b/cloud/aws/runtime/resource/resource.go
@@ -216,6 +216,13 @@ func (a *AwsResourceService) populateCache(ctx context.Context) error {
 							a.cache[typ] = map[string]ResolvedResource{}
 						}
 
+						// Check the value doesn't already exist
+						if _, ok := a.cache[typ][*t.Value]; ok {
+							// Clear the cache to avoid partial data and allow for a retry if a manual fix is applied
+							a.cache = nil
+							return fmt.Errorf("unable to uniquely identify %s resource, multiple resources found with matching name: %s: ARNs: %s, %s", typ, *t.Value, a.cache[typ][*t.Value].ARN, *tm.ResourceARN)
+						}
+
 						a.cache[typ][*t.Value] = ResolvedResource{ARN: *tm.ResourceARN}
 						break
 					}


### PR DESCRIPTION
Might be better to limit the fallout of this error to just the specific resource that's duplicated - this currently impacts all resources.

Happy to make that change if we think it's better, it'll just take bit more work. Trade off is if the duplicate resource is rarely used it could go unnoticed for a while without detection.