### PR TITLE
fix: add missing gcp api gateway services to gcp cloud project.go

### DIFF
--- a/cloud/gcp/deploy/project.go
+++ b/cloud/gcp/deploy/project.go
@@ -56,6 +56,10 @@ var requiredServices = []string{
 	"cloudtasks.googleapis.com",
 	// Enable monitoring API
 	"monitoring.googleapis.com",
+	// Enable Service Management API
+	"servicemanagement.googleapis.com",
+	// Enable Service Control API
+	"servicecontrol.googleapis.com",
 }
 
 // Creates a new GCP Project


### PR DESCRIPTION
<!---
Thanks for your contribution! Please ensure that you have read the [Contribution guide](https://github.com/nitrictech/nitric/blob/main/CONTRIBUTING.md).
-->

# Description

I am assuming based on the documentation we should be activating the correct services for GCP for API Gateway. I couldn't from a fresh nitric project generation access the API Gateway dashboard as we are missing dependant services not being applied during the nitric up command.

- fixes https://github.com/nitrictech/nitric/issues/658
- [Link to docs - api gateway and cloud run](https://cloud.google.com/api-gateway/docs/get-started-cloud-run)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Not sure how to test and run the project <---- needs a second pair of eyes :)
