### PR TITLE
fix(aws/batch): Add config for increasing docker system volume size via launch template

### DIFF
--- a/cloud/aws/common/config.go
+++ b/cloud/aws/common/config.go
@@ -33,10 +33,26 @@ type AwsImports struct {
 	Buckets map[string]string
 }
 
+type EcsBlockDevice struct {
+	Dev
+}
+
+type EcsLaunchTemplate struct {
+	BlockDeviceMappings []struct {
+		DeviceName string `mapstructure:"device-name,omitempty"`
+		Ebs        struct {
+			DeleteOnTermination string `mapstructure:"delete-on-termination,omitempty"`
+			VolumeSize          int    `mapstructure:"volume-size,omitempty"`
+			VolumeType          string `mapstructure:"volume-type,omitempty"`
+		} `mapstructure:"ebs,omitempty"`
+	} `mapstructure:"block-device-mappings,omitempty"`
+}
+
 type BatchComputeEnvConfig struct {
-	MinCpus       int      `mapstructure:"min-cpus"`
-	MaxCpus       int      `mapstructure:"max-cpus"`
-	InstanceTypes []string `mapstructure:"instance-types"`
+	MinCpus        int                `mapstructure:"min-cpus"`
+	MaxCpus        int                `mapstructure:"max-cpus"`
+	InstanceTypes  []string           `mapstructure:"instance-types"`
+	LaunchTemplate *EcsLaunchTemplate `mapstructure:"launch-template,omitempty"`
 }
 
 type AwsConfig struct {
@@ -72,9 +88,10 @@ var defaultLambdaConfig = &AwsLambdaConfig{
 }
 
 var defaultBatchComputeEnvConfig = &BatchComputeEnvConfig{
-	MinCpus:       0,
-	MaxCpus:       32,
-	InstanceTypes: []string{"optimal"},
+	MinCpus:        0,
+	MaxCpus:        32,
+	InstanceTypes:  []string{"optimal"},
+	LaunchTemplate: nil,
 }
 
 var defaultAwsConfigItem = AwsConfigItem{

--- a/cloud/aws/common/config.go
+++ b/cloud/aws/common/config.go
@@ -33,10 +33,6 @@ type AwsImports struct {
 	Buckets map[string]string
 }
 
-type EcsBlockDevice struct {
-	Dev
-}
-
 type EcsLaunchTemplate struct {
 	BlockDeviceMappings []struct {
 		DeviceName string `mapstructure:"device-name,omitempty"`


### PR DESCRIPTION
Adds configuration for block device mapping:
```yaml
batch-compute-env:
  min-cpus: 0
  max-cpus: 4
  instance-types:
    - g5
    - optimal
  # Customize the ECS launch template for this compute environment
  launch-template:
    # Increase the default docker system volume size
    block-device-mappings:
      - device-name: /dev/xvda
        ebs:
          volume-size: 20
          volume-type: gp2
          delete-on-termination: "true"
```
Will allow configuration of larger default system volume sizes.

In future we may want to consider configuring volume/bucket mounts for batch/services         