### PR TITLE
fix: podman support for all core providers

### DIFF
--- a/cloud/aws/deploy/batch.go
+++ b/cloud/aws/deploy/batch.go
@@ -225,7 +225,6 @@ func (p *NitricAwsPulumiProvider) Batch(ctx *pulumi.Context, parent pulumi.Resou
 		SourceImage:   config.GetImage().GetUri(),
 		RepositoryUrl: repo.RepositoryUrl,
 		Runtime:       runtime(),
-		RegistryArgs:  p.RegistryArgs,
 	}, pulumi.Parent(parent), pulumi.DependsOn([]pulumi.Resource{repo}), pulumi.Provider(p.DockerProvider))
 	if err != nil {
 		return err

--- a/cloud/aws/deploy/service.go
+++ b/cloud/aws/deploy/service.go
@@ -73,7 +73,7 @@ func (a *NitricAwsPulumiProvider) Service(ctx *pulumi.Context, parent pulumi.Res
 		RepositoryUrl: repo.RepositoryUrl,
 		RegistryArgs:  a.RegistryArgs,
 		Runtime:       runtime(),
-	}, pulumi.Parent(parent), pulumi.DependsOn([]pulumi.Resource{repo}))
+	}, pulumi.Parent(parent), pulumi.DependsOn([]pulumi.Resource{repo}), pulumi.Provider(a.DockerProvider))
 	// image, err := createImage(ctx, parent, name, repo, config, a.DockerProvider, runtime)
 	if err != nil {
 		return err

--- a/cloud/aws/deploy/service.go
+++ b/cloud/aws/deploy/service.go
@@ -71,7 +71,6 @@ func (a *NitricAwsPulumiProvider) Service(ctx *pulumi.Context, parent pulumi.Res
 	image, err := image.NewImage(ctx, name, &image.ImageArgs{
 		SourceImage:   config.GetImage().GetUri(),
 		RepositoryUrl: repo.RepositoryUrl,
-		RegistryArgs:  a.RegistryArgs,
 		Runtime:       runtime(),
 	}, pulumi.Parent(parent), pulumi.DependsOn([]pulumi.Resource{repo}), pulumi.Provider(a.DockerProvider))
 	// image, err := createImage(ctx, parent, name, repo, config, a.DockerProvider, runtime)

--- a/cloud/azure/deploy/service.go
+++ b/cloud/azure/deploy/service.go
@@ -166,7 +166,6 @@ func (p *NitricAzurePulumiProvider) Service(ctx *pulumi.Context, parent pulumi.R
 	image, err := image.NewImage(ctx, name, &image.ImageArgs{
 		SourceImage:   service.GetImage().Uri,
 		RepositoryUrl: repositoryUrl,
-		RegistryArgs:  p.ContainerEnv.RegistryArgs,
 		Runtime:       runtime(),
 	}, opts...)
 	if err != nil {

--- a/cloud/azure/deploy/sql.go
+++ b/cloud/azure/deploy/sql.go
@@ -53,7 +53,6 @@ func (a *NitricAzurePulumiProvider) SqlDatabase(ctx *pulumi.Context, parent pulu
 			SourceImage:   config.GetImageUri(),
 			SourceImageID: inspect.ID,
 			RepositoryUrl: repositoryUrl,
-			RegistryArgs:  a.ContainerEnv.RegistryArgs,
 		}, pulumi.Provider(a.ContainerEnv.DockerProvider))
 		if err != nil {
 			return err

--- a/cloud/common/deploy/image/image.go
+++ b/cloud/common/deploy/image/image.go
@@ -50,7 +50,7 @@ type Image struct {
 	pulumi.ResourceState
 
 	Name        string
-	DockerImage *docker.Image
+	DockerImage *docker.RegistryImage
 }
 
 type WrappedBuildInput struct {
@@ -99,7 +99,7 @@ func NewLocalImage(ctx *pulumi.Context, name string, args *LocalImageArgs, opts 
 		return nil, err
 	}
 
-	res.DockerImage, err = docker.NewImage(ctx, name+"-image", &docker.ImageArgs{
+	image, err := docker.NewImage(ctx, name+"-image", &docker.ImageArgs{
 		ImageName: args.RepositoryUrl,
 		Build: docker.DockerBuildArgs{
 			Context:    pulumi.String(buildContext),
@@ -110,26 +110,25 @@ func NewLocalImage(ctx *pulumi.Context, name string, args *LocalImageArgs, opts 
 			},
 			Platform: pulumi.String("linux/amd64"),
 		},
-		Registry: args.RegistryArgs,
-		SkipPush: pulumi.Bool(false),
+		SkipPush: pulumi.Bool(true),
 	}, defaultOpts...)
 	if err != nil {
 		return nil, err
 	}
 
-	// res.DockerImage, err = docker.NewRegistryImage(ctx, name+"-image", &docker.RegistryImageArgs{
-	// 	Name: image.ImageName,
-	// 	Triggers: pulumi.Map{
-	// 		"hash": image.RepoDigest,
-	// 	},
-	// }, defaultOpts...)
-	// if err != nil {
-	// 	return nil, err
-	// }
+	res.DockerImage, err = docker.NewRegistryImage(ctx, name+"-image", &docker.RegistryImageArgs{
+		Name: image.ImageName,
+		Triggers: pulumi.Map{
+			"hash": image.RepoDigest,
+		},
+	}, defaultOpts...)
+	if err != nil {
+		return nil, err
+	}
 
 	return res, ctx.RegisterResourceOutputs(res, pulumi.Map{
 		"name":     pulumi.String(res.Name),
-		"imageUri": res.DockerImage.RepoDigest,
+		"imageUri": pulumi.Sprintf("%s@%s", res.DockerImage.Name, res.DockerImage.Sha256Digest),
 	})
 }
 
@@ -203,7 +202,7 @@ func NewImage(ctx *pulumi.Context, name string, args *ImageArgs, opts ...pulumi.
 		"BASE_IMAGE_ID": sourceImageID,
 	}, imageWrapper.Args)
 
-	res.DockerImage, err = docker.NewImage(ctx, name+"-image", &docker.ImageArgs{
+	image, err := docker.NewImage(ctx, name+"-image", &docker.ImageArgs{
 		ImageName: args.RepositoryUrl,
 		Build: docker.DockerBuildArgs{
 			Context:    pulumi.String(buildContext),
@@ -211,31 +210,30 @@ func NewImage(ctx *pulumi.Context, name string, args *ImageArgs, opts ...pulumi.
 			Args:       buildArgs,
 			Platform:   pulumi.String("linux/amd64"),
 		},
-		Registry: args.RegistryArgs,
-		SkipPush: pulumi.Bool(false),
+		SkipPush: pulumi.Bool(true),
 	}, defaultOpts...)
 	if err != nil {
 		return nil, err
 	}
 
-	// res.DockerImage, err = docker.NewRegistryImage(ctx, name+"-image", &docker.RegistryImageArgs{
-	// 	Name: image.ImageName,
-	// 	Triggers: pulumi.Map{
-	// 		"hash": image.RepoDigest,
-	// 	},
-	// }, defaultOpts...)
-	// if err != nil {
-	// 	return nil, err
-	// }
+	res.DockerImage, err = docker.NewRegistryImage(ctx, name+"-image", &docker.RegistryImageArgs{
+		Name: image.ImageName,
+		Triggers: pulumi.Map{
+			"hash": image.RepoDigest,
+		},
+	}, defaultOpts...)
+	if err != nil {
+		return nil, err
+	}
 
 	return res, ctx.RegisterResourceOutputs(res, pulumi.Map{
 		"name":     pulumi.String(res.Name),
-		"imageUri": res.DockerImage.RepoDigest,
+		"imageUri": pulumi.Sprintf("%s@%s", res.DockerImage.Name, res.DockerImage.Sha256Digest),
 	})
 }
 
 func (d *Image) URI() pulumi.StringOutput {
-	return d.DockerImage.RepoDigest.Elem() // pulumi.Sprintf("%s@%s", d.DockerImage.Name, d.DockerImage.Sha256Digest)
+	return pulumi.Sprintf("%s@%s", d.DockerImage.Name, d.DockerImage.Sha256Digest)
 }
 
 // Returns the default docker file if telemetry sampling is disabled for this service. Otherwise, will return a wrapped telemetry image.

--- a/cloud/common/deploy/image/image.go
+++ b/cloud/common/deploy/image/image.go
@@ -36,13 +36,11 @@ type ImageArgs struct {
 	SourceImage   string
 	Runtime       []byte
 	RepositoryUrl pulumi.StringInput
-	RegistryArgs  *docker.RegistryArgs
 }
 
 type LocalImageArgs struct {
 	SourceImage   string
 	SourceImageID string
-	RegistryArgs  *docker.RegistryArgs
 	RepositoryUrl pulumi.StringInput
 }
 

--- a/cloud/common/deploy/provider/dependencies.go
+++ b/cloud/common/deploy/provider/dependencies.go
@@ -31,16 +31,6 @@ func checkPulumiAvailable() error {
 	return nil
 }
 
-func checkDockerAvailable() error {
-	cmd := exec.Command("docker", "info")
-	err := cmd.Run()
-	if err != nil {
-		return fmt.Errorf("docker is required to use this provider, please install docker and try again")
-	}
-
-	return nil
-}
-
 func checkDependencies(checks ...DependencyCheck) error {
 	errs := []error{}
 

--- a/cloud/common/deploy/provider/pulumi.go
+++ b/cloud/common/deploy/provider/pulumi.go
@@ -208,7 +208,7 @@ func parsePulumiError(err error) error {
 // Up - automatically called by the Nitric CLI via the `up` command
 func (s *PulumiProviderServer) Up(req *deploymentspb.DeploymentUpRequest, stream deploymentspb.Deployment_UpServer) error {
 	// Verify if dependencies are available
-	if err := checkDependencies(checkPulumiAvailable, checkDockerAvailable); err != nil {
+	if err := checkDependencies(checkPulumiAvailable); err != nil {
 		return status.Error(codes.FailedPrecondition, err.Error())
 	}
 
@@ -288,7 +288,7 @@ func (s *PulumiProviderServer) Up(req *deploymentspb.DeploymentUpRequest, stream
 // Down - automatically called by the Nitric CLI via the `down` command
 func (s *PulumiProviderServer) Down(req *deploymentspb.DeploymentDownRequest, stream deploymentspb.Deployment_DownServer) error {
 	// Verify if dependencies are available
-	if err := checkDependencies(checkPulumiAvailable, checkDockerAvailable); err != nil {
+	if err := checkDependencies(checkPulumiAvailable); err != nil {
 		return status.Error(codes.FailedPrecondition, err.Error())
 	}
 

--- a/cloud/common/deploy/provider/pulumi.go
+++ b/cloud/common/deploy/provider/pulumi.go
@@ -208,7 +208,7 @@ func parsePulumiError(err error) error {
 // Up - automatically called by the Nitric CLI via the `up` command
 func (s *PulumiProviderServer) Up(req *deploymentspb.DeploymentUpRequest, stream deploymentspb.Deployment_UpServer) error {
 	// Verify if dependencies are available
-	if err := checkDependencies(checkPulumiAvailable); err != nil {
+	if err := checkDependencies(checkPulumiAvailable, checkDockerAvailable); err != nil {
 		return status.Error(codes.FailedPrecondition, err.Error())
 	}
 
@@ -288,7 +288,7 @@ func (s *PulumiProviderServer) Up(req *deploymentspb.DeploymentUpRequest, stream
 // Down - automatically called by the Nitric CLI via the `down` command
 func (s *PulumiProviderServer) Down(req *deploymentspb.DeploymentDownRequest, stream deploymentspb.Deployment_DownServer) error {
 	// Verify if dependencies are available
-	if err := checkDependencies(checkPulumiAvailable); err != nil {
+	if err := checkDependencies(checkPulumiAvailable, checkDockerAvailable); err != nil {
 		return status.Error(codes.FailedPrecondition, err.Error())
 	}
 

--- a/cloud/gcp/deploy/batch.go
+++ b/cloud/gcp/deploy/batch.go
@@ -49,7 +49,6 @@ func (p *NitricGcpPulumiProvider) Batch(ctx *pulumi.Context, parent pulumi.Resou
 	image, err := image.NewImage(ctx, fmt.Sprintf("batch-image-%s", name), &image.ImageArgs{
 		SourceImage:   config.GetImage().Uri,
 		RepositoryUrl: pulumi.Sprintf("%s-docker.pkg.dev/%s/%s/%s", p.Region, p.GcpConfig.ProjectId, p.ContainerRegistry.Name, imageName),
-		RegistryArgs:  p.RegistryArgs,
 		Runtime:       runtimeProvider(),
 	}, p.WithDefaultResourceOptions(defaultResourceOpts...)...)
 	if err != nil {

--- a/cloud/gcp/deploy/service.go
+++ b/cloud/gcp/deploy/service.go
@@ -80,7 +80,6 @@ func (p *NitricGcpPulumiProvider) Service(ctx *pulumi.Context, parent pulumi.Res
 	image, err := image.NewImage(ctx, gcpServiceName, &image.ImageArgs{
 		SourceImage:   config.GetImage().Uri,
 		RepositoryUrl: pulumi.Sprintf("%s-docker.pkg.dev/%s/%s/%s", p.Region, p.GcpConfig.ProjectId, p.ContainerRegistry.Name, imageName),
-		RegistryArgs:  p.RegistryArgs,
 		Runtime:       runtime(),
 	}, p.WithDefaultResourceOptions(opts...)...)
 	if err != nil {


### PR DESCRIPTION
We previously checked specifically for the docker binary on path, but we only interact with the API. Since Podman offers a compatible API, removing the binary check allows podman to work with all nitric providers when it's in docker compatibility mode.