### PR TITLE
fix: AWS resource lookup

### DIFF
--- a/cloud/aws/cmd/runtime/main.go
+++ b/cloud/aws/cmd/runtime/main.go
@@ -23,8 +23,8 @@ import (
 )
 
 func main() {
-	var resolver resource.AwsResourceResolver = nil
-	var err error = nil
+	var resolver resource.AwsResourceResolver
+	var err error
 
 	resolver, err = resource.NewSSMResourceResolver()
 

--- a/cloud/aws/cmd/runtime/main.go
+++ b/cloud/aws/cmd/runtime/main.go
@@ -16,13 +16,22 @@ package main
 
 import (
 	"github.com/nitrictech/nitric/cloud/aws/runtime"
+	"github.com/nitrictech/nitric/cloud/aws/runtime/env"
 	"github.com/nitrictech/nitric/cloud/aws/runtime/resource"
 	"github.com/nitrictech/nitric/core/pkg/logger"
 	"github.com/nitrictech/nitric/core/pkg/server"
 )
 
 func main() {
-	resolver, err := resource.New()
+	var resolver resource.AwsResourceResolver = nil
+	var err error = nil
+
+	resolver, err = resource.NewSSMResourceResolver()
+
+	if env.NITRIC_AWS_RESOURCE_RESOLVER.String() == "tagging" {
+		resolver, err = resource.NewTaggedResourceResolver()
+	}
+
 	if err != nil {
 		logger.Fatalf("could not create aws resource resolver: %v", err)
 		return

--- a/cloud/aws/common/index.go
+++ b/cloud/aws/common/index.go
@@ -1,0 +1,37 @@
+package common
+
+// AwsResourceName - Provides a type hint for the mapping of Nitric resource names to AWS resource names
+type AwsResourceName = string
+
+// AwsResourceArn - Provides a type hint for the mapping of Nitric resource names to AWS resource ARNs
+type AwsResourceArn = string
+
+type ApiGateway struct {
+	Arn      string `json:"arn"`
+	Endpoint string `json:"endpoint"`
+}
+
+// ResourceIndex - The resource index for a nitric stack
+type ResourceIndex struct {
+	// Buckets - The S3 Buckets
+	// This is a map of Nitric Name to AWS Bucket name
+	Buckets    map[string]AwsResourceName `json:"buckets"`
+	Topics     map[string]string          `json:"topics"`
+	KvStores   map[string]string          `json:"kvStores"`
+	Queues     map[string]string          `json:"queues"`
+	Secrets    map[string]string          `json:"secrets"`
+	Apis       map[string]ApiGateway      `json:"apis"`
+	Websockets map[string]ApiGateway      `json:"websockets"`
+}
+
+func NewResourceIndex() *ResourceIndex {
+	return &ResourceIndex{
+		Buckets:    make(map[string]AwsResourceName),
+		Topics:     make(map[string]string),
+		KvStores:   make(map[string]string),
+		Queues:     make(map[string]string),
+		Secrets:    make(map[string]string),
+		Apis:       make(map[string]ApiGateway),
+		Websockets: make(map[string]ApiGateway),
+	}
+}

--- a/cloud/aws/common/index.go
+++ b/cloud/aws/common/index.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Nitric Technologies Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 // AwsResourceName - Provides a type hint for the mapping of Nitric resource names to AWS resource names
@@ -11,27 +25,34 @@ type ApiGateway struct {
 	Endpoint string `json:"endpoint"`
 }
 
+type Topic struct {
+	Arn             string `json:"arn"`
+	StateMachineArn string `json:"stateMachineArn"`
+}
+
 // ResourceIndex - The resource index for a nitric stack
 type ResourceIndex struct {
-	// Buckets - The S3 Buckets
-	// This is a map of Nitric Name to AWS Bucket name
-	Buckets    map[string]AwsResourceName `json:"buckets"`
-	Topics     map[string]string          `json:"topics"`
-	KvStores   map[string]string          `json:"kvStores"`
-	Queues     map[string]string          `json:"queues"`
-	Secrets    map[string]string          `json:"secrets"`
-	Apis       map[string]ApiGateway      `json:"apis"`
-	Websockets map[string]ApiGateway      `json:"websockets"`
+	Buckets     map[string]AwsResourceName `json:"buckets"`
+	Topics      map[string]Topic           `json:"topics"`
+	KvStores    map[string]AwsResourceArn  `json:"kvStores"`
+	Queues      map[string]AwsResourceArn  `json:"queues"`
+	Secrets     map[string]AwsResourceArn  `json:"secrets"`
+	Apis        map[string]ApiGateway      `json:"apis"`
+	HttpProxies map[string]ApiGateway      `json:"httpProxies"`
+	Websockets  map[string]ApiGateway      `json:"websockets"`
+	Schedules   map[string]AwsResourceArn  `json:"schedules"`
 }
 
 func NewResourceIndex() *ResourceIndex {
 	return &ResourceIndex{
-		Buckets:    make(map[string]AwsResourceName),
-		Topics:     make(map[string]string),
-		KvStores:   make(map[string]string),
-		Queues:     make(map[string]string),
-		Secrets:    make(map[string]string),
-		Apis:       make(map[string]ApiGateway),
-		Websockets: make(map[string]ApiGateway),
+		Buckets:     make(map[string]AwsResourceName),
+		Topics:      make(map[string]Topic),
+		KvStores:    make(map[string]AwsResourceArn),
+		Queues:      make(map[string]AwsResourceArn),
+		Secrets:     make(map[string]AwsResourceArn),
+		Apis:        make(map[string]ApiGateway),
+		HttpProxies: make(map[string]ApiGateway),
+		Websockets:  make(map[string]ApiGateway),
+		Schedules:   make(map[string]AwsResourceArn),
 	}
 }

--- a/cloud/aws/common/index.go
+++ b/cloud/aws/common/index.go
@@ -32,15 +32,15 @@ type Topic struct {
 
 // ResourceIndex - The resource index for a nitric stack
 type ResourceIndex struct {
-	Buckets     map[string]AwsResourceName `json:"buckets"`
-	Topics      map[string]Topic           `json:"topics"`
-	KvStores    map[string]AwsResourceArn  `json:"kvStores"`
-	Queues      map[string]AwsResourceArn  `json:"queues"`
-	Secrets     map[string]AwsResourceArn  `json:"secrets"`
-	Apis        map[string]ApiGateway      `json:"apis"`
-	HttpProxies map[string]ApiGateway      `json:"httpProxies"`
-	Websockets  map[string]ApiGateway      `json:"websockets"`
-	Schedules   map[string]AwsResourceArn  `json:"schedules"`
+	Buckets     map[string]AwsResourceArn `json:"buckets"`
+	Topics      map[string]Topic          `json:"topics"`
+	KvStores    map[string]AwsResourceArn `json:"kvStores"`
+	Queues      map[string]AwsResourceArn `json:"queues"`
+	Secrets     map[string]AwsResourceArn `json:"secrets"`
+	Apis        map[string]ApiGateway     `json:"apis"`
+	HttpProxies map[string]ApiGateway     `json:"httpProxies"`
+	Websockets  map[string]ApiGateway     `json:"websockets"`
+	Schedules   map[string]AwsResourceArn `json:"schedules"`
 }
 
 func NewResourceIndex() *ResourceIndex {

--- a/cloud/aws/deploy/deploy.go
+++ b/cloud/aws/deploy/deploy.go
@@ -230,7 +230,12 @@ func (a *NitricAwsPulumiProvider) Pre(ctx *pulumi.Context, resources []*pulumix.
 }
 
 func (a *NitricAwsPulumiProvider) Post(ctx *pulumi.Context) error {
-	return a.applyVpcRules(ctx)
+	err := a.applyVpcRules(ctx)
+	if err != nil {
+		return err
+	}
+
+	return a.resourcesStore(ctx)
 }
 
 func (a *NitricAwsPulumiProvider) Result(ctx *pulumi.Context) (pulumi.StringOutput, error) {

--- a/cloud/aws/deploy/deploy.go
+++ b/cloud/aws/deploy/deploy.go
@@ -43,6 +43,7 @@ import (
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/rds"
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/resourcegroups"
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/s3"
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/scheduler"
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/secretsmanager"
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/sqs"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/codebuild"
@@ -96,6 +97,7 @@ type NitricAwsPulumiProvider struct {
 	Websockets            map[string]*apigatewayv2.Api
 	KeyValueStores        map[string]*dynamodb.Table
 	JobDefinitions        map[string]*batch.JobDefinition
+	Schedules             map[string]*scheduler.Schedule
 
 	provider.NitricDefaultOrder
 

--- a/cloud/aws/deploy/resources.go
+++ b/cloud/aws/deploy/resources.go
@@ -157,7 +157,6 @@ func (a *NitricAwsPulumiProvider) resourcesStore(ctx *pulumi.Context) error {
 		}
 
 		indexJson, err := json.Marshal(index)
-
 		if err != nil {
 			return "", err
 		}

--- a/cloud/aws/deploy/resources.go
+++ b/cloud/aws/deploy/resources.go
@@ -1,0 +1,68 @@
+package deploy
+
+import (
+	"encoding/json"
+
+	"github.com/nitrictech/nitric/cloud/aws/common"
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ssm"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func (a *NitricAwsPulumiProvider) resourcesStore(ctx *pulumi.Context) error {
+	// Build the AWS resource index from the provider information
+	// This will be used to store the ARNs of all resources created by the stack
+	bucketNameMap := pulumi.StringMap{}
+	for name, bucket := range a.Buckets {
+		bucketNameMap[name] = bucket.Bucket
+	}
+
+	apiArnMap := pulumi.StringMap{}
+	for name, api := range a.Apis {
+		apiArnMap[name] = api.Arn
+	}
+
+	apiEndpointMap := pulumi.StringMap{}
+	for name, api := range a.Apis {
+		apiEndpointMap[name] = api.ApiEndpoint
+	}
+
+	// Build the index from the provider information
+	resourceIndexJson := pulumi.All(bucketNameMap, apiArnMap, apiEndpointMap).ApplyT(func(args []interface{}) (string, error) {
+		bucketNameMap := args[0].(map[string]string)
+		apiArnMap := args[1].(map[string]string)
+		apiEndpointMap := args[2].(map[string]string)
+
+		index := common.NewResourceIndex()
+		for name, bucket := range bucketNameMap {
+			index.Buckets[name] = bucket
+		}
+
+		for name, arn := range apiArnMap {
+			index.Apis[name] = common.ApiGateway{
+				Arn:      arn,
+				Endpoint: apiEndpointMap[name],
+			}
+		}
+
+		indexJson, err := json.Marshal(index)
+
+		if err != nil {
+			return "", err
+		}
+
+		return string(indexJson), nil
+	}).(pulumi.StringOutput)
+
+	_, err := ssm.NewParameter(ctx, "nitric-resource-index", &ssm.ParameterArgs{
+		// Create a deterministic name for the resource index
+		Name:     pulumi.Sprintf("/nitric/%s/resource-index", a.StackId),
+		DataType: pulumi.String("text"),
+		Type:     pulumi.String("String"),
+		// Store the nitric resource index serialized as a JSON string
+		Value: resourceIndexJson,
+	})
+
+	// TODO: give services permission to read this parameter store
+
+	return err
+}

--- a/cloud/aws/deploy/resources.go
+++ b/cloud/aws/deploy/resources.go
@@ -1,16 +1,31 @@
+// Copyright 2021 Nitric Technologies Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package deploy
 
 import (
 	"encoding/json"
 
 	"github.com/nitrictech/nitric/cloud/aws/common"
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/iam"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ssm"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 func (a *NitricAwsPulumiProvider) resourcesStore(ctx *pulumi.Context) error {
 	// Build the AWS resource index from the provider information
-	// This will be used to store the ARNs of all resources created by the stack
+	// This will be used to store the ARNs/Identifiers of all resources created by the stack
 	bucketNameMap := pulumi.StringMap{}
 	for name, bucket := range a.Buckets {
 		bucketNameMap[name] = bucket.Bucket
@@ -26,11 +41,75 @@ func (a *NitricAwsPulumiProvider) resourcesStore(ctx *pulumi.Context) error {
 		apiEndpointMap[name] = api.ApiEndpoint
 	}
 
+	websocketArnMap := pulumi.StringMap{}
+	for name, api := range a.Websockets {
+		apiArnMap[name] = api.Arn
+	}
+
+	websocketEndpointMap := pulumi.StringMap{}
+	for name, api := range a.Websockets {
+		apiEndpointMap[name] = api.ApiEndpoint
+	}
+
+	topicArnMap := pulumi.StringMap{}
+	stateMachArnMap := pulumi.StringMap{}
+	for name, topic := range a.Topics {
+		topicArnMap[name] = topic.sns.Arn
+		stateMachArnMap[name] = topic.sfn.Arn
+	}
+
+	kvStoreArnMap := pulumi.StringMap{}
+	for name, kvStore := range a.KeyValueStores {
+		kvStoreArnMap[name] = kvStore.Arn
+	}
+
+	queueArnMap := pulumi.StringMap{}
+	for name, queue := range a.Queues {
+		queueArnMap[name] = queue.Arn
+	}
+
+	secretsArnMap := pulumi.StringMap{}
+	for name, secret := range a.Secrets {
+		secretsArnMap[name] = secret.Arn
+	}
+
+	httpProxyArnMap := pulumi.StringMap{}
+	for name, proxy := range a.HttpProxies {
+		httpProxyArnMap[name] = proxy.Arn
+	}
+
+	httpProxyEndpointMap := pulumi.StringMap{}
+	for name, proxy := range a.HttpProxies {
+		httpProxyEndpointMap[name] = proxy.ApiEndpoint
+	}
+
 	// Build the index from the provider information
-	resourceIndexJson := pulumi.All(bucketNameMap, apiArnMap, apiEndpointMap).ApplyT(func(args []interface{}) (string, error) {
+	resourceIndexJson := pulumi.All(
+		bucketNameMap,
+		apiArnMap,
+		apiEndpointMap,
+		websocketArnMap,
+		websocketEndpointMap,
+		topicArnMap,
+		kvStoreArnMap,
+		queueArnMap,
+		secretsArnMap,
+		stateMachArnMap,
+		httpProxyArnMap,
+		httpProxyEndpointMap,
+	).ApplyT(func(args []interface{}) (string, error) {
 		bucketNameMap := args[0].(map[string]string)
 		apiArnMap := args[1].(map[string]string)
 		apiEndpointMap := args[2].(map[string]string)
+		websocketArnMap := args[3].(map[string]string)
+		websocketEndpointMap := args[4].(map[string]string)
+		topicArnMap := args[5].(map[string]string)
+		kvStoreArnMap := args[6].(map[string]string)
+		queueArnMap := args[7].(map[string]string)
+		secretsArnMap := args[8].(map[string]string)
+		stateMachArnMap := args[9].(map[string]string)
+		httpProxyArnMap := args[10].(map[string]string)
+		httpProxyEndpointMap := args[11].(map[string]string)
 
 		index := common.NewResourceIndex()
 		for name, bucket := range bucketNameMap {
@@ -42,6 +121,39 @@ func (a *NitricAwsPulumiProvider) resourcesStore(ctx *pulumi.Context) error {
 				Arn:      arn,
 				Endpoint: apiEndpointMap[name],
 			}
+		}
+
+		for name, arn := range websocketArnMap {
+			index.Websockets[name] = common.ApiGateway{
+				Arn:      arn,
+				Endpoint: websocketEndpointMap[name],
+			}
+		}
+
+		for name, arn := range httpProxyArnMap {
+			index.HttpProxies[name] = common.ApiGateway{
+				Arn:      arn,
+				Endpoint: httpProxyEndpointMap[name],
+			}
+		}
+
+		for name, arn := range topicArnMap {
+			index.Topics[name] = common.Topic{
+				Arn:             arn,
+				StateMachineArn: stateMachArnMap[name],
+			}
+		}
+
+		for name, arn := range kvStoreArnMap {
+			index.KvStores[name] = arn
+		}
+
+		for name, arn := range queueArnMap {
+			index.Queues[name] = arn
+		}
+
+		for name, arn := range secretsArnMap {
+			index.Secrets[name] = arn
 		}
 
 		indexJson, err := json.Marshal(index)
@@ -61,8 +173,45 @@ func (a *NitricAwsPulumiProvider) resourcesStore(ctx *pulumi.Context) error {
 		// Store the nitric resource index serialized as a JSON string
 		Value: resourceIndexJson,
 	})
+	if err != nil {
+		return err
+	}
 
-	// TODO: give services permission to read this parameter store
+	// Create a role that gives read access to the above parameter
+	policy, err := iam.NewPolicy(ctx, "nitric-index-policy", &iam.PolicyArgs{Policy: pulumi.Sprintf(`{
+				"Version": "2012-10-17",
+				"Statement": [
+					{
+						"Effect": "Allow",
+						"Action": "ssm:GetParameter",
+						"Resource": "arn:aws:ssm:*:*:parameter/nitric/%s/resource-index"
+					}
+				]
+			}`, a.StackId)},
+	)
+	if err != nil {
+		return err
+	}
 
-	return err
+	for name, role := range a.LambdaRoles {
+		_, err = iam.NewRolePolicyAttachment(ctx, name+"NitricIndexAccess", &iam.RolePolicyAttachmentArgs{
+			PolicyArn: policy.Arn,
+			Role:      role.ID(),
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	for name, role := range a.BatchRoles {
+		_, err = iam.NewRolePolicyAttachment(ctx, name+"NitricIndexAccess", &iam.RolePolicyAttachmentArgs{
+			PolicyArn: policy.Arn,
+			Role:      role.ID(),
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/cloud/aws/deploy/resources.go
+++ b/cloud/aws/deploy/resources.go
@@ -28,7 +28,7 @@ func (a *NitricAwsPulumiProvider) resourcesStore(ctx *pulumi.Context) error {
 	// This will be used to store the ARNs/Identifiers of all resources created by the stack
 	bucketNameMap := pulumi.StringMap{}
 	for name, bucket := range a.Buckets {
-		bucketNameMap[name] = bucket.Bucket
+		bucketNameMap[name] = bucket.Arn
 	}
 
 	apiArnMap := pulumi.StringMap{}

--- a/cloud/aws/deploy/schedule.go
+++ b/cloud/aws/deploy/schedule.go
@@ -74,7 +74,7 @@ func (a *NitricAwsPulumiProvider) Schedule(ctx *pulumi.Context, parent pulumi.Re
 	}
 
 	// Create a new eventbridge schedule
-	_, err = scheduler.NewSchedule(ctx, name, &scheduler.ScheduleArgs{
+	a.Schedules[name], err = scheduler.NewSchedule(ctx, name, &scheduler.ScheduleArgs{
 		ScheduleExpression:         pulumi.String(awsScheduleExpression),
 		ScheduleExpressionTimezone: pulumi.String(a.AwsConfig.ScheduleTimezone),
 		FlexibleTimeWindow: &scheduler.ScheduleFlexibleTimeWindowArgs{

--- a/cloud/aws/deploytf/service.go
+++ b/cloud/aws/deploytf/service.go
@@ -47,10 +47,11 @@ func (a *NitricAwsTerraformProvider) Service(stack cdktf.TerraformStack, name st
 	}
 
 	jsiiEnv := map[string]*string{
-		"NITRIC_STACK_ID":        a.Stack.StackIdOutput(),
-		"NITRIC_ENVIRONMENT":     jsii.String("cloud"),
-		"MIN_WORKERS":            jsii.String(fmt.Sprint(config.Workers)),
-		"NITRIC_HTTP_PROXY_PORT": jsii.String(fmt.Sprint(3000)),
+		"NITRIC_STACK_ID":            a.Stack.StackIdOutput(),
+		"NITRIC_ENVIRONMENT":         jsii.String("cloud"),
+		"MIN_WORKERS":                jsii.String(fmt.Sprint(config.Workers)),
+		"NITRIC_HTTP_PROXY_PORT":     jsii.String(fmt.Sprint(3000)),
+		"NITRIC_AWS_RESOURCE_PLUGIN": jsii.String("tagging"),
 	}
 
 	// TODO: Only apply to requesting services

--- a/cloud/aws/go.mod
+++ b/cloud/aws/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-lambda-go v1.34.1
 	github.com/aws/aws-sdk-go v1.44.298
-	github.com/aws/aws-sdk-go-v2 v1.30.4
+	github.com/aws/aws-sdk-go-v2 v1.32.5
 	github.com/aws/aws-sdk-go-v2/config v1.27.4
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.13.6
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression v1.7.6
@@ -24,7 +24,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.31.1
 	github.com/aws/constructs-go/constructs/v10 v10.3.0
 	github.com/aws/jsii-runtime-go v1.99.0
-	github.com/aws/smithy-go v1.20.4
+	github.com/aws/smithy-go v1.22.1
 	github.com/cdktf/cdktf-provider-aws-go/aws/v19 v19.20.1
 	github.com/cdktf/cdktf-provider-docker-go/docker/v11 v11.0.0
 	github.com/getkin/kin-openapi v0.113.0
@@ -90,8 +90,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.1 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.4 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.15.2 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.16 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.16 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.24 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.24 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.20.1 // indirect
@@ -100,6 +100,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.17.2 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.55.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.20.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.1 // indirect

--- a/cloud/aws/go.sum
+++ b/cloud/aws/go.sum
@@ -124,6 +124,8 @@ github.com/aws/aws-sdk-go v1.44.298 h1:5qTxdubgV7PptZJmp/2qDwD2JL187ePL7VOxsSh1i
 github.com/aws/aws-sdk-go v1.44.298/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v1.30.4 h1:frhcagrVNrzmT95RJImMHgabt99vkXGslubDaDagTk8=
 github.com/aws/aws-sdk-go-v2 v1.30.4/go.mod h1:CT+ZPWXbYrci8chcARI3OmI/qgd+f6WtuLOoaIA8PR0=
+github.com/aws/aws-sdk-go-v2 v1.32.5 h1:U8vdWJuY7ruAkzaOdD7guwJjD06YSKmnKCJs7s3IkIo=
+github.com/aws/aws-sdk-go-v2 v1.32.5/go.mod h1:P5WJBrYqqbWVaOxgH0X/FYYD47/nooaPOZPlQdmiN2U=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.1 h1:gTK2uhtAPtFcdRRJilZPx8uJLL2J85xK11nKtWL0wfU=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.1/go.mod h1:sxpLb+nZk7tIfCWChfd+h4QwHNUR57d8hA1cleTkjJo=
 github.com/aws/aws-sdk-go-v2/config v1.27.4 h1:AhfWb5ZwimdsYTgP7Od8E9L1u4sKmDW2ZVeLcf2O42M=
@@ -138,8 +140,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.15.2 h1:AK0J8iYBFeUk2Ax7O8YpLtF
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.15.2/go.mod h1:iRlGzMix0SExQEviAyptRWRGdYNo3+ufW/lCzvKVTUc=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.16 h1:TNyt/+X43KJ9IJJMjKfa3bNTiZbUP7DeCxfbTROESwY=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.16/go.mod h1:2DwJF39FlNAUiX5pAc0UNeiz16lK2t7IaFcm0LFHEgc=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.24 h1:4usbeaes3yJnCFC7kfeyhkdkPtoRYPa/hTmCqMpKpLI=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.24/go.mod h1:5CI1JemjVwde8m2WG3cz23qHKPOxbpkq0HaoreEgLIY=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.16 h1:jYfy8UPmd+6kJW5YhY0L1/KftReOGxI/4NtVSTh9O/I=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.16/go.mod h1:7ZfEPZxkW42Afq4uQB8H2E2e6ebh6mXTueEpYzjCzcs=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.24 h1:N1zsICrQglfzaBnrfM0Ys00860C+QFwu6u/5+LomP+o=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.24/go.mod h1:dCn9HbJ8+K31i8IQ8EWmWj0EiIk0+vKiHNMxTTYveAg=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 h1:hT8rVHwugYE2lEfdFE0QWVo81lF7jMrYJVDWI+f+VxU=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0/go.mod h1:8tu/lYfQfFe6IGnaOdrpVgEL2IrrDOf6/m9RQum4NkY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.2 h1:en92G0Z7xlksoOylkUhuBSfJgijC7rHVLRdnIlHEs0E=
@@ -176,6 +182,8 @@ github.com/aws/aws-sdk-go-v2/service/sns v1.29.1 h1:K2FiR/547lI9vGuDL0Ghin4QPSEv
 github.com/aws/aws-sdk-go-v2/service/sns v1.29.1/go.mod h1:PBmfgVv83oBgZVFhs/+oWsL6r0hLyB6qHRFEWwHyHn4=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.31.1 h1:124rVNP6NbCfBZwiX1kfjMQrnsJtnpKeB0GalkuqSXo=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.31.1/go.mod h1:YijRvM1SAmuiIQ9pjfwahIEE3HMHUkx9P5oplL/Jnj4=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.55.6 h1:mh6Osa3cjwaaVSzJ92a8x1dBh8XQ7ekKLHyhjtx5RRw=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.55.6/go.mod h1:l9qF25TzH95FhcIak6e4vt79KE4I7M2Nf59eMUVjj6c=
 github.com/aws/aws-sdk-go-v2/service/sso v1.20.1 h1:utEGkfdQ4L6YW/ietH7111ZYglLJvS+sLriHJ1NBJEQ=
 github.com/aws/aws-sdk-go-v2/service/sso v1.20.1/go.mod h1:RsYqzYr2F2oPDdpy+PdhephuZxTfjHQe7SOBcZGoAU8=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.1 h1:9/GylMS45hGGFCcMrUZDVayQE1jYSIN6da9jo7RAYIw=
@@ -188,6 +196,8 @@ github.com/aws/jsii-runtime-go v1.99.0 h1:IYnRyyimwcWwa/bR39/tCkkGqhzqjAsdtfLin4
 github.com/aws/jsii-runtime-go v1.99.0/go.mod h1:zAzY1FrPQXQwG/ZrtHIyZI22vKoZm9dufF7LqsJ1poE=
 github.com/aws/smithy-go v1.20.4 h1:2HK1zBdPgRbjFOHlfeQZfpC4r72MOb9bZkiFwggKO+4=
 github.com/aws/smithy-go v1.20.4/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/aws/smithy-go v1.22.1 h1:/HPHZQ0g7f4eUeK6HKglFz8uwVfZKgoI25rb/J+dnro=
+github.com/aws/smithy-go v1.22.1/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=

--- a/cloud/aws/mocks/provider/aws.go
+++ b/cloud/aws/mocks/provider/aws.go
@@ -8,7 +8,6 @@ import (
 	context "context"
 	reflect "reflect"
 
-	apigatewayv2 "github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	gomock "github.com/golang/mock/gomock"
 	resource "github.com/nitrictech/nitric/cloud/aws/runtime/resource"
 	resourcespb "github.com/nitrictech/nitric/core/pkg/proto/resources/v1"
@@ -53,10 +52,10 @@ func (mr *MockAwsResourceResolverMockRecorder) GetAWSApiGatewayDetails(arg0, arg
 }
 
 // GetApiGatewayById mocks base method.
-func (m *MockAwsResourceResolver) GetApiGatewayById(arg0 context.Context, arg1 string) (*apigatewayv2.GetApiOutput, error) {
+func (m *MockAwsResourceResolver) GetApiGatewayById(arg0 context.Context, arg1 string) (*resource.ApiGatewayDetails, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApiGatewayById", arg0, arg1)
-	ret0, _ := ret[0].(*apigatewayv2.GetApiOutput)
+	ret0, _ := ret[0].(*resource.ApiGatewayDetails)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/cloud/aws/runtime/env/variables.go
+++ b/cloud/aws/runtime/env/variables.go
@@ -24,3 +24,5 @@ var GATEWAY_ENVIRONMENT = env.GetEnv("GATEWAY_ENVIRONMENT", "lambda")
 
 // JOB_QUEUE_ARN - The AWS ARN of the job queue to use for job execution
 var JOB_QUEUE_ARN = env.GetEnv("NITRIC_JOB_QUEUE_ARN", "")
+
+var NITRIC_AWS_RESOURCE_RESOLVER = env.GetEnv("NITRIC_AWS_RESOURCE_RESOLVER", "ssm")

--- a/cloud/aws/runtime/gateway/router.go
+++ b/cloud/aws/runtime/gateway/router.go
@@ -24,8 +24,6 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/nitrictech/nitric/cloud/aws/runtime/resource"
-	"github.com/nitrictech/nitric/cloud/common/deploy/tags"
-	commonenv "github.com/nitrictech/nitric/cloud/common/runtime/env"
 	"github.com/nitrictech/nitric/core/pkg/logger"
 	apispb "github.com/nitrictech/nitric/core/pkg/proto/apis/v1"
 	schedulespb "github.com/nitrictech/nitric/core/pkg/proto/schedules/v1"
@@ -174,21 +172,10 @@ func handleApiEvent(ctx context.Context, resolver resource.AwsResourceResolver, 
 		return nil, err
 	}
 
-	stackID := commonenv.NITRIC_STACK_ID.String()
-	nitricName, ok := api.Tags[tags.GetResourceNameKey(stackID)]
-	if !ok {
-		return nil, fmt.Errorf("received request from non-nitric API gateway")
-	}
-
-	nitricType, ok := api.Tags[tags.GetResourceTypeKey(stackID)]
-	if !ok {
-		return nil, fmt.Errorf("received request from non-nitric API gateway")
-	}
-
-	if nitricType == "http-proxy" {
+	if api.Type == "http-proxy" {
 		return handleHttpProxyRequest(ctx, httpmanager, evt)
 	} else {
-		return handleApiGatewayRequest(ctx, nitricName, apismanager, evt)
+		return handleApiGatewayRequest(ctx, api.Name, apismanager, evt)
 	}
 }
 
@@ -322,11 +309,7 @@ func handleWebsocketEvent(ctx context.Context, resolver resource.AwsResourceReso
 		return nil, err
 	}
 
-	stackID := commonenv.NITRIC_STACK_ID.String()
-	nitricName, ok := api.Tags[tags.GetResourceNameKey(stackID)]
-	if !ok {
-		return nil, fmt.Errorf("received websocket trigger from non-nitric API gateway")
-	}
+	nitricName := api.Name
 
 	// Use the routekey to get the event type
 	wsEvent := &websocketspb.ServerMessage_WebsocketEventRequest{

--- a/cloud/aws/runtime/resource/resource.go
+++ b/cloud/aws/runtime/resource/resource.go
@@ -64,7 +64,7 @@ type ResolvedResource struct {
 }
 
 // Aws core utility provider
-type AwsResourceService struct {
+type AwsTaggedResourceResolver struct {
 	stackID   string
 	cacheLock sync.Mutex
 	client    resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
@@ -73,19 +73,19 @@ type AwsResourceService struct {
 }
 
 type AwsResourceResolver interface {
-	GetApiGatewayById(context.Context, string) (*apigatewayv2.GetApiOutput, error)
+	GetApiGatewayById(ctx context.Context, apiId string) (*ApiGatewayDetails, error)
 	GetAWSApiGatewayDetails(ctx context.Context, identifier *resourcespb.ResourceIdentifier) (*AWSApiGatewayDetails, error)
 	GetResources(context.Context, AwsResource) (map[string]ResolvedResource, error)
 }
 
-var _ AwsResourceResolver = &AwsResourceService{}
+var _ AwsResourceResolver = &AwsTaggedResourceResolver{}
 
 type AWSApiGatewayDetails struct {
 	Url string
 }
 
 // GetAWSApiGatewayDetails - Get the details for an AWS API Gateway resource related to a Nitric API or Websocket
-func (a *AwsResourceService) GetAWSApiGatewayDetails(ctx context.Context, identifier *resourcespb.ResourceIdentifier) (*AWSApiGatewayDetails, error) {
+func (a *AwsTaggedResourceResolver) GetAWSApiGatewayDetails(ctx context.Context, identifier *resourcespb.ResourceIdentifier) (*AWSApiGatewayDetails, error) {
 	resourceName := identifier.Name
 	resourceType := identifier.Type
 
@@ -119,14 +119,27 @@ func (a *AwsResourceService) GetAWSApiGatewayDetails(ctx context.Context, identi
 	}
 
 	return &AWSApiGatewayDetails{
-		Url: *api.ApiEndpoint,
+		Url: api.ApiEndpoint,
 	}, nil
 }
 
-func (a *AwsResourceService) GetApiGatewayById(ctx context.Context, apiId string) (*apigatewayv2.GetApiOutput, error) {
-	return a.apiClient.GetApi(context.TODO(), &apigatewayv2.GetApiInput{
+func (a *AwsTaggedResourceResolver) GetApiGatewayById(ctx context.Context, apiId string) (*ApiGatewayDetails, error) {
+	api, err := a.apiClient.GetApi(context.TODO(), &apigatewayv2.GetApiInput{
 		ApiId: aws.String(apiId),
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	nitricName := api.Tags[tags.GetResourceNameKey(a.stackID)]
+	nitricType := api.Tags[tags.GetResourceTypeKey(a.stackID)]
+
+	return &ApiGatewayDetails{
+		Name:        nitricName,
+		Type:        nitricType,
+		ApiEndpoint: *api.ApiEndpoint,
+	}, nil
+
 }
 
 func resourceTypeFromArn(arn string) (string, error) {
@@ -162,7 +175,7 @@ func resourceTypeFromArn(arn string) (string, error) {
 }
 
 // populate the resource cache
-func (a *AwsResourceService) populateCache(ctx context.Context) error {
+func (a *AwsTaggedResourceResolver) populateCache(ctx context.Context) error {
 	a.cacheLock.Lock()
 	defer a.cacheLock.Unlock()
 	if a.cache == nil {
@@ -245,7 +258,7 @@ func (e *ResourceResolutionError) Unwrap() error {
 	return e.Cause
 }
 
-func (a *AwsResourceService) GetResources(ctx context.Context, typ AwsResource) (map[string]ResolvedResource, error) {
+func (a *AwsTaggedResourceResolver) GetResources(ctx context.Context, typ AwsResource) (map[string]ResolvedResource, error) {
 	if err := a.populateCache(ctx); err != nil {
 		return nil, &ResourceResolutionError{
 			Msg:   "error populating resource cache",
@@ -256,7 +269,7 @@ func (a *AwsResourceService) GetResources(ctx context.Context, typ AwsResource) 
 	return a.cache[typ], nil
 }
 
-func New() (*AwsResourceService, error) {
+func NewTaggedResourceResolver() (*AwsTaggedResourceResolver, error) {
 	awsRegion := env.AWS_REGION.String()
 	stackID := commonenv.NITRIC_STACK_ID.String()
 
@@ -275,7 +288,7 @@ func New() (*AwsResourceService, error) {
 	apiClient := apigatewayv2.NewFromConfig(cfg)
 	client := resourcegroupstaggingapi.NewFromConfig(cfg)
 
-	return &AwsResourceService{
+	return &AwsTaggedResourceResolver{
 		stackID:   stackID,
 		client:    client,
 		cacheLock: sync.Mutex{},

--- a/cloud/aws/runtime/resource/resource.go
+++ b/cloud/aws/runtime/resource/resource.go
@@ -139,7 +139,6 @@ func (a *AwsTaggedResourceResolver) GetApiGatewayById(ctx context.Context, apiId
 		Type:        nitricType,
 		ApiEndpoint: *api.ApiEndpoint,
 	}, nil
-
 }
 
 func resourceTypeFromArn(arn string) (string, error) {

--- a/cloud/aws/runtime/resource/resource_test.go
+++ b/cloud/aws/runtime/resource/resource_test.go
@@ -30,7 +30,7 @@ import (
 
 var _ = Describe("AwsProvider", func() {
 	When("Calling get resources with filled cache", func() {
-		provider := &AwsResourceService{
+		provider := &AwsTaggedResourceResolver{
 			cache: map[string]map[string]ResolvedResource{
 				AwsResource_Bucket: {
 					"test": ResolvedResource{
@@ -53,7 +53,7 @@ var _ = Describe("AwsProvider", func() {
 		When("Call to GetResources fails", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			mockClient := mocks.NewMockResourceGroupsTaggingAPIAPI(ctrl)
-			provider := &AwsResourceService{
+			provider := &AwsTaggedResourceResolver{
 				client:  mockClient,
 				stackID: "test-stack",
 			}
@@ -77,7 +77,7 @@ var _ = Describe("AwsProvider", func() {
 		When("Call to GetResources succeeds", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			mockClient := mocks.NewMockResourceGroupsTaggingAPIAPI(ctrl)
-			provider := &AwsResourceService{
+			provider := &AwsTaggedResourceResolver{
 				client:  mockClient,
 				stackID: "test-stackID",
 			}

--- a/cloud/aws/runtime/resource/ssm.go
+++ b/cloud/aws/runtime/resource/ssm.go
@@ -80,8 +80,9 @@ func (a *AwsSSMResourceResolver) GetApiGatewayById(ctx context.Context, apiId st
 	for name, api := range a.cache.Apis {
 		if strings.HasSuffix(api.Arn, apiId) {
 			return &ApiGatewayDetails{
-				Name: name,
-				Type: "api",
+				Name:        name,
+				Type:        "api",
+				ApiEndpoint: api.Endpoint,
 			}, nil
 		}
 	}
@@ -89,8 +90,9 @@ func (a *AwsSSMResourceResolver) GetApiGatewayById(ctx context.Context, apiId st
 	for name, api := range a.cache.HttpProxies {
 		if strings.HasSuffix(api.Arn, apiId) {
 			return &ApiGatewayDetails{
-				Name: name,
-				Type: "http-proxy",
+				Name:        name,
+				Type:        "http-proxy",
+				ApiEndpoint: api.Endpoint,
 			}, nil
 		}
 	}
@@ -98,8 +100,9 @@ func (a *AwsSSMResourceResolver) GetApiGatewayById(ctx context.Context, apiId st
 	for name, api := range a.cache.Websockets {
 		if strings.HasSuffix(api.Arn, apiId) {
 			return &ApiGatewayDetails{
-				Name: name,
-				Type: "websocket",
+				Name:        name,
+				Type:        "websocket",
+				ApiEndpoint: api.Endpoint,
 			}, nil
 		}
 	}

--- a/cloud/aws/runtime/resource/ssm.go
+++ b/cloud/aws/runtime/resource/ssm.go
@@ -190,6 +190,12 @@ func (a *AwsSSMResourceResolver) GetResources(ctx context.Context, typ AwsResour
 				ARN: secret,
 			}
 		}
+	case AwsResource_Queue:
+		for name, queue := range a.cache.Queues {
+			resolvedResources[name] = ResolvedResource{
+				ARN: queue,
+			}
+		}
 	}
 
 	return resolvedResources, nil

--- a/cloud/aws/runtime/resource/ssm.go
+++ b/cloud/aws/runtime/resource/ssm.go
@@ -143,7 +143,7 @@ func (a *AwsSSMResourceResolver) populateCache(ctx context.Context) error {
 	return nil
 }
 
-func (a *AwsSSMResourceResolver) GetResources(ctx context.Context, typ AwsResource) (map[string]ResolvedResource, error) {
+func (a *AwsSSMResourceResolver) GetResources(ctx context.Context, resourceType AwsResource) (map[string]ResolvedResource, error) {
 	if err := a.populateCache(ctx); err != nil {
 		return nil, &ResourceResolutionError{
 			Msg:   "error populating resource cache",
@@ -153,7 +153,7 @@ func (a *AwsSSMResourceResolver) GetResources(ctx context.Context, typ AwsResour
 
 	resolvedResources := map[string]ResolvedResource{}
 
-	switch typ {
+	switch resourceType {
 	case AwsResource_Api:
 		for name, api := range a.cache.Apis {
 			resolvedResources[name] = ResolvedResource{

--- a/cloud/aws/runtime/resource/ssm.go
+++ b/cloud/aws/runtime/resource/ssm.go
@@ -1,0 +1,218 @@
+// Copyright 2021 Nitric Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws"
+
+	"github.com/nitrictech/nitric/cloud/aws/common"
+	"github.com/nitrictech/nitric/cloud/aws/runtime/env"
+	commonenv "github.com/nitrictech/nitric/cloud/common/runtime/env"
+	resourcepb "github.com/nitrictech/nitric/core/pkg/proto/resources/v1"
+	resourcespb "github.com/nitrictech/nitric/core/pkg/proto/resources/v1"
+)
+
+// Aws core utility provider
+type AwsSSMResourceResolver struct {
+	stackID   string
+	cacheLock sync.Mutex
+	// Bot, give me the ssm  client here
+	client *ssm.Client
+
+	cache *common.ResourceIndex
+}
+
+var _ AwsResourceResolver = &AwsSSMResourceResolver{}
+
+// GetAWSApiGatewayDetails - Get the details for an AWS API Gateway resource related to a Nitric API or Websocket
+func (a *AwsSSMResourceResolver) GetAWSApiGatewayDetails(ctx context.Context, identifier *resourcespb.ResourceIdentifier) (*AWSApiGatewayDetails, error) {
+	resourceName := identifier.Name
+	resourceType := identifier.Type
+
+	endpoint := ""
+	switch resourceType {
+	case resourcepb.ResourceType_Api:
+		endpoint = a.cache.Apis[resourceName].Endpoint
+	case resourcepb.ResourceType_Websocket:
+		endpoint = a.cache.Websockets[resourceName].Endpoint
+	}
+
+	return &AWSApiGatewayDetails{
+		Url: endpoint,
+	}, nil
+}
+
+type ApiGatewayDetails struct {
+	Name        string
+	Type        string
+	ApiEndpoint string
+}
+
+func (a *AwsSSMResourceResolver) GetApiGatewayById(ctx context.Context, apiId string) (*ApiGatewayDetails, error) {
+	err := a.populateCache(ctx)
+	if err != nil {
+		return nil, err
+	}
+	a.cacheLock.Lock()
+	defer a.cacheLock.Unlock()
+
+	for name, api := range a.cache.Apis {
+		if strings.HasSuffix(api.Arn, apiId) {
+			return &ApiGatewayDetails{
+				Name: name,
+				Type: "api",
+			}, nil
+		}
+	}
+
+	for name, api := range a.cache.HttpProxies {
+		if strings.HasSuffix(api.Arn, apiId) {
+			return &ApiGatewayDetails{
+				Name: name,
+				Type: "http-proxy",
+			}, nil
+		}
+	}
+
+	for name, api := range a.cache.Websockets {
+		if strings.HasSuffix(api.Arn, apiId) {
+			return &ApiGatewayDetails{
+				Name: name,
+				Type: "websocket",
+			}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("api gateway not found")
+}
+
+// populate the resource cache
+func (a *AwsSSMResourceResolver) populateCache(ctx context.Context) error {
+	a.cacheLock.Lock()
+	defer a.cacheLock.Unlock()
+
+	if a.cache != nil {
+		return nil
+	}
+
+	response, err := a.client.GetParameter(ctx, &ssm.GetParameterInput{
+		Name: aws.String(fmt.Sprintf("/nitric/%s/resource-index", a.stackID)),
+	})
+	if err != nil {
+		return err
+	}
+
+	val := response.Parameter.Value
+	if val == nil {
+		return fmt.Errorf("resource index not found")
+	}
+
+	var index common.ResourceIndex
+
+	err = json.Unmarshal([]byte(*val), &index)
+	if err != nil {
+		return fmt.Errorf("error unmarshalling resource index: %w", err)
+	}
+
+	a.cache = &index
+
+	return nil
+}
+
+func (a *AwsSSMResourceResolver) GetResources(ctx context.Context, typ AwsResource) (map[string]ResolvedResource, error) {
+	if err := a.populateCache(ctx); err != nil {
+		return nil, &ResourceResolutionError{
+			Msg:   "error populating resource cache",
+			Cause: err,
+		}
+	}
+
+	resolvedResources := map[string]ResolvedResource{}
+
+	switch typ {
+	case AwsResource_Api:
+		for name, api := range a.cache.Apis {
+			resolvedResources[name] = ResolvedResource{
+				ARN: api.Arn,
+			}
+		}
+	case AwsResource_StateMachine:
+		for name, topic := range a.cache.Topics {
+			resolvedResources[name] = ResolvedResource{
+				ARN: topic.StateMachineArn,
+			}
+		}
+	case AwsResource_Topic:
+		for name, topic := range a.cache.Topics {
+			resolvedResources[name] = ResolvedResource{
+				ARN: topic.Arn,
+			}
+		}
+	case AwsResource_Collection:
+		for name, collection := range a.cache.KvStores {
+			resolvedResources[name] = ResolvedResource{
+				ARN: collection,
+			}
+		}
+	case AwsResource_Bucket:
+		for name, bucket := range a.cache.Buckets {
+			resolvedResources[name] = ResolvedResource{
+				ARN: bucket,
+			}
+		}
+	case AwsResource_Secret:
+		for name, secret := range a.cache.Secrets {
+			resolvedResources[name] = ResolvedResource{
+				ARN: secret,
+			}
+		}
+	}
+
+	return resolvedResources, nil
+}
+
+func NewSSMResourceResolver() (*AwsSSMResourceResolver, error) {
+	awsRegion := env.AWS_REGION.String()
+	stackID := commonenv.NITRIC_STACK_ID.String()
+
+	cfg, sessionError := config.LoadDefaultConfig(
+		context.TODO(),
+		config.WithRegion(awsRegion),
+		config.WithRetryMode(aws.RetryModeAdaptive),
+		config.WithRetryMaxAttempts(10),
+	)
+	if sessionError != nil {
+		return nil, fmt.Errorf("error creating new AWS session %w", sessionError)
+	}
+
+	otelaws.AppendMiddlewares(&cfg.APIOptions)
+
+	client := ssm.NewFromConfig(cfg)
+
+	return &AwsSSMResourceResolver{
+		stackID:   stackID,
+		client:    client,
+		cacheLock: sync.Mutex{},
+	}, nil
+}


### PR DESCRIPTION
Updates nitric resource lookup to use SSM parameters instead of the resourcetaggingapi.