### PR TITLE
fix: issue retrieving api runtime url

### DIFF
--- a/cloud/aws/runtime/api/api.go
+++ b/cloud/aws/runtime/api/api.go
@@ -31,7 +31,7 @@ type AwsApiGatewayProvider struct {
 
 var _ apispb.ApiServer = &AwsApiGatewayProvider{}
 
-func (a *AwsApiGatewayProvider) Details(ctx context.Context, req *apispb.ApiDetailsRequest) (*apispb.ApiDetailsResponse, error) {
+func (a *AwsApiGatewayProvider) ApiDetails(ctx context.Context, req *apispb.ApiDetailsRequest) (*apispb.ApiDetailsResponse, error) {
 	gwDetails, err := a.resolver.GetAWSApiGatewayDetails(ctx, &resourcespb.ResourceIdentifier{
 		Type: resourcespb.ResourceType_Api,
 		Name: req.ApiName,

--- a/cloud/azure/runtime/api/api.go
+++ b/cloud/azure/runtime/api/api.go
@@ -29,7 +29,7 @@ type AzureApiGatewayProvider struct {
 
 var _ apispb.ApiServer = &AzureApiGatewayProvider{}
 
-func (g *AzureApiGatewayProvider) Details(ctx context.Context, req *apispb.ApiDetailsRequest) (*apispb.ApiDetailsResponse, error) {
+func (g *AzureApiGatewayProvider) ApiDetails(ctx context.Context, req *apispb.ApiDetailsRequest) (*apispb.ApiDetailsResponse, error) {
 	gwDetails, err := g.provider.GetApiDetails(ctx, req.ApiName)
 	if err != nil {
 		return nil, err

--- a/cloud/gcp/runtime/api/api.go
+++ b/cloud/gcp/runtime/api/api.go
@@ -29,7 +29,7 @@ type GcpApiGatewayProvider struct {
 
 var _ apispb.ApiServer = &GcpApiGatewayProvider{}
 
-func (g *GcpApiGatewayProvider) Details(ctx context.Context, req *apispb.ApiDetailsRequest) (*apispb.ApiDetailsResponse, error) {
+func (g *GcpApiGatewayProvider) ApiDetails(ctx context.Context, req *apispb.ApiDetailsRequest) (*apispb.ApiDetailsResponse, error) {
 	gwDetails, err := g.provider.GetApiGatewayDetails(ctx, req.ApiName)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Required rename, caused a non implemented error when using the url method on an api resource.
