### PR TITLE
fix(aws): improve the error if an undefined service is declared in APIs

### DIFF
--- a/cloud/aws/deploytf/api.go
+++ b/cloud/aws/deploytf/api.go
@@ -100,7 +100,10 @@ func (n *NitricAwsTerraformProvider) Api(stack cdktf.TerraformStack, name string
 		for _, pathOperation := range apiPath.Operations() {
 			if apiNitricTarget, ok := pathOperation.Extensions["x-nitric-target"]; ok {
 				if targetMap, isMap := apiNitricTarget.(map[string]any); isMap {
-					serviceName := targetMap["name"].(string)
+					serviceName, ok := targetMap["name"].(string)
+					if !ok {
+						return fmt.Errorf("missing or invalid 'name' field in x-nitric-target for path %s on API %s", pathOperation.OperationID, name)
+					}
 
 					nitricService, ok := n.Services[serviceName]
 					if !ok {


### PR DESCRIPTION
This error can't occur with standard nitric providers, but catching it helps with custom providers that may edit the API spec before generating the AWS specific spec.

Currently this panics with a invalid memory address or nil pointer dereference error message, which makes it unclear what went wrong.