### PR TITLE
fix(storage): consistently detect and store content-type when writing files

### DIFF
--- a/cloud/aws/runtime/storage/s3.go
+++ b/cloud/aws/runtime/storage/s3.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -33,6 +32,7 @@ import (
 	"github.com/nitrictech/nitric/cloud/aws/ifaces/s3iface"
 	"github.com/nitrictech/nitric/cloud/aws/runtime/env"
 	"github.com/nitrictech/nitric/cloud/aws/runtime/resource"
+	content "github.com/nitrictech/nitric/cloud/common/runtime/storage"
 	grpc_errors "github.com/nitrictech/nitric/core/pkg/grpc/errors"
 	storagepb "github.com/nitrictech/nitric/core/pkg/proto/storage/v1"
 )
@@ -130,7 +130,7 @@ func (s *S3StorageService) Write(ctx context.Context, req *storagepb.StorageWrit
 	newErr := grpc_errors.ErrorsWithScope("S3StorageService.Write")
 
 	if b, err := s.getS3BucketName(ctx, req.BucketName); err == nil {
-		contentType := http.DetectContentType(req.Body)
+		contentType := content.DetectContentType(req.Key, req.Body)
 
 		if _, err := s.s3Client.PutObject(ctx, &s3.PutObjectInput{
 			Bucket:      b,

--- a/cloud/azure/runtime/storage/azblob.go
+++ b/cloud/azure/runtime/storage/azblob.go
@@ -30,6 +30,7 @@ import (
 	"github.com/nitrictech/nitric/cloud/azure/runtime/env"
 	azblob_service_iface "github.com/nitrictech/nitric/cloud/azure/runtime/storage/iface"
 	azureutils "github.com/nitrictech/nitric/cloud/azure/runtime/utils"
+	content "github.com/nitrictech/nitric/cloud/common/runtime/storage"
 	grpc_errors "github.com/nitrictech/nitric/core/pkg/grpc/errors"
 	"github.com/nitrictech/nitric/core/pkg/logger"
 	storagepb "github.com/nitrictech/nitric/core/pkg/proto/storage/v1"
@@ -90,12 +91,16 @@ func (a *AzblobStorageService) Read(ctx context.Context, req *storagepb.StorageR
 func (a *AzblobStorageService) Write(ctx context.Context, req *storagepb.StorageWriteRequest) (*storagepb.StorageWriteResponse, error) {
 	newErr := grpc_errors.ErrorsWithScope("AzblobStorageService.Write")
 
+	contentType := content.DetectContentType(req.Key, req.Body)
+
 	blob := a.getBlobUrl(req.BucketName, req.Key)
 
 	if _, err := blob.Upload(
 		ctx,
 		bytes.NewReader(req.Body),
-		azblob.BlobHTTPHeaders{},
+		azblob.BlobHTTPHeaders{
+			ContentType: contentType,
+		},
 		azblob.Metadata{},
 		azblob.BlobAccessConditions{},
 		azblob.DefaultAccessTier,

--- a/cloud/azure/runtime/storage/azblob_test.go
+++ b/cloud/azure/runtime/storage/azblob_test.go
@@ -148,7 +148,9 @@ var _ = Describe("Azblob", func() {
 				mockBlob.EXPECT().Upload(
 					gomock.Any(),
 					bytes.NewReader([]byte("test")),
-					azblob.BlobHTTPHeaders{},
+					azblob.BlobHTTPHeaders{
+						ContentType: "text/plain; charset=utf-8",
+					},
 					azblob.Metadata{},
 					azblob.BlobAccessConditions{},
 					azblob.DefaultAccessTier,
@@ -190,7 +192,9 @@ var _ = Describe("Azblob", func() {
 				mockBlob.EXPECT().Upload(
 					gomock.Any(),
 					bytes.NewReader([]byte("test")),
-					azblob.BlobHTTPHeaders{},
+					azblob.BlobHTTPHeaders{
+						ContentType: "text/plain; charset=utf-8",
+					},
 					azblob.Metadata{},
 					azblob.BlobAccessConditions{},
 					azblob.DefaultAccessTier,

--- a/cloud/common/runtime/storage/storage.go
+++ b/cloud/common/runtime/storage/storage.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Nitric Technologies Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package storage
 
 import (

--- a/cloud/common/runtime/storage/storage.go
+++ b/cloud/common/runtime/storage/storage.go
@@ -1,0 +1,19 @@
+package storage
+
+import (
+	"mime"
+	"net/http"
+	"path/filepath"
+)
+
+// DetectContentType - detects content type using the file's extension or content.
+// Extension matching is performed first, if the content type can't be determined by the file extension then the file contents will be inspected to attempt to determine the content type.
+// If the content type cannot be determined it returns "application/octet-stream"
+func DetectContentType(filename string, content []byte) string {
+	contentType := mime.TypeByExtension(filepath.Ext(filename))
+	if contentType != "" {
+		return contentType
+	}
+
+	return http.DetectContentType(content)
+}

--- a/cloud/gcp/ifaces/gcloud_storage/adapter.go
+++ b/cloud/gcp/ifaces/gcloud_storage/adapter.go
@@ -68,6 +68,10 @@ func (o objectHandle) NewWriter(ctx context.Context) Writer {
 	return writer{o.ObjectHandle.NewWriter(ctx)}
 }
 
+func (w writer) ObjectAttrs() *storage.ObjectAttrs {
+	return &w.Writer.ObjectAttrs
+}
+
 func (o objectHandle) NewReader(ctx context.Context) (Reader, error) {
 	newReader, err := o.ObjectHandle.NewReader(ctx)
 	return reader{newReader}, err

--- a/cloud/gcp/ifaces/gcloud_storage/iface.go
+++ b/cloud/gcp/ifaces/gcloud_storage/iface.go
@@ -23,6 +23,7 @@ import (
 
 type Writer interface {
 	io.WriteCloser
+	ObjectAttrs() *storage.ObjectAttrs
 }
 
 type Reader interface {

--- a/cloud/gcp/mocks/gcp_storage/mock.go
+++ b/cloud/gcp/mocks/gcp_storage/mock.go
@@ -102,6 +102,20 @@ func (mr *MockWriterMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockWriter)(nil).Close))
 }
 
+// ObjectAttrs mocks base method.
+func (m *MockWriter) ObjectAttrs() *storage.ObjectAttrs {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ObjectAttrs")
+	ret0, _ := ret[0].(*storage.ObjectAttrs)
+	return ret0
+}
+
+// ObjectAttrs indicates an expected call of ObjectAttrs.
+func (mr *MockWriterMockRecorder) ObjectAttrs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectAttrs", reflect.TypeOf((*MockWriter)(nil).ObjectAttrs))
+}
+
 // Write mocks base method.
 func (m *MockWriter) Write(arg0 []byte) (int, error) {
 	m.ctrl.T.Helper()

--- a/cloud/gcp/runtime/storage/storage.go
+++ b/cloud/gcp/runtime/storage/storage.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/codes"
 
+	content "github.com/nitrictech/nitric/cloud/common/runtime/storage"
 	ifaces_gcloud_storage "github.com/nitrictech/nitric/cloud/gcp/ifaces/gcloud_storage"
 	grpc_errors "github.com/nitrictech/nitric/core/pkg/grpc/errors"
 	storagePb "github.com/nitrictech/nitric/core/pkg/proto/storage/v1"
@@ -153,6 +154,7 @@ func (s *StorageStorageService) Write(ctx context.Context, req *storagePb.Storag
 	}
 
 	writer := bucketHandle.Object(req.Key).NewWriter(ctx)
+	writer.ObjectAttrs().ContentType = content.DetectContentType(req.Key, req.Body)
 
 	if _, err := writer.Write(req.Body); err != nil {
 		if isPermissionDenied(err) {

--- a/cloud/gcp/runtime/storage/storage_test.go
+++ b/cloud/gcp/runtime/storage/storage_test.go
@@ -73,6 +73,9 @@ var _ = Describe("Storage", func() {
 
 					By("The bytes being written")
 					mockWriter.EXPECT().Write(testPayload).Times(1)
+					mockWriter.EXPECT().ObjectAttrs().Times(1).Return(&storage.ObjectAttrs{
+						ContentType: "application/octet-stream",
+					})
 					mockWriter.EXPECT().Close().Times(1)
 
 					_, err := mockStorageServer.Write(context.TODO(), &storagePb.StorageWriteRequest{
@@ -143,6 +146,9 @@ var _ = Describe("Storage", func() {
 					mockBucket.EXPECT().Object("test-file").Return(mockObject)
 
 					mockObject.EXPECT().NewWriter(gomock.Any()).Return(mockWriter)
+					mockWriter.EXPECT().ObjectAttrs().Times(1).Return(&storage.ObjectAttrs{
+						ContentType: "application/octet-stream",
+					})
 					mockWriter.EXPECT().Write(gomock.Any()).Return(0, &googleapi.Error{Code: 403, Message: "insufficient permissions"})
 
 					_, err := mockStorageServer.Write(context.TODO(), &storagePb.StorageWriteRequest{


### PR DESCRIPTION
Apply the same content-type detection scheme to all supported clouds