### PR TITLE
fix(azure): prevent conflicting topic subscription names

### DIFF
--- a/cloud/azure/deploy/topic.go
+++ b/cloud/azure/deploy/topic.go
@@ -59,17 +59,20 @@ func (p *NitricAzurePulumiProvider) newEventGridTopicSubscription(ctx *pulumi.Co
 
 	subName := topicName + "-" + config.GetService()
 
-	subscriptionId, err := random.NewRandomId(ctx, subName+"-ID", &random.RandomIdArgs{
-		Prefix:     pulumi.String("sub"),
-		ByteLength: pulumi.Int(EventSubscriptionRT.MaxLen - 3),
-		Keepers:    pulumi.Map{"subName": pulumi.String(subName)},
+	subscriptionId, err := random.NewRandomString(ctx, subName+"-ID", &random.RandomStringArgs{
+		Length:  pulumi.Int(EventSubscriptionRT.MaxLen),
+		Keepers: pulumi.Map{"subName": pulumi.String(subName)},
+		Upper:   pulumi.Bool(true),
+		Lower:   pulumi.Bool(true),
+		Special: pulumi.Bool(false),
+		Number:  pulumi.Bool(false),
 	})
 	if err != nil {
 		return err
 	}
 
 	_, err = eventgrid.NewEventSubscription(ctx, subName, &eventgrid.EventSubscriptionArgs{
-		EventSubscriptionName: subscriptionId.ID(),
+		EventSubscriptionName: subscriptionId.Result,
 		Scope:                 topic.ID(),
 		RetryPolicy: eventgrid.RetryPolicyArgs{
 			MaxDeliveryAttempts:      pulumi.Int(30),

--- a/cloud/azure/deploytf/.nitric/modules/topic/main.tf
+++ b/cloud/azure/deploytf/.nitric/modules/topic/main.tf
@@ -3,14 +3,23 @@ resource "azurerm_eventgrid_topic" "topic" {
   name                = var.name
   resource_group_name = var.resource_group_name
   location            = var.location
-  tags = var.tags
+  tags                = var.tags
+}
+
+# Generate random string for each event subscription name
+resource "random_string" "event_subscription_name" {
+  for_each = var.listeners
+
+  length  = 24
+  special = false
+  upper   = false
 }
 
 # Create an event subscription per listener
 resource "azurerm_eventgrid_event_subscription" "subscription" {
   for_each = var.listeners
 
-  name  = each.key
+  name  = random_string.event_subscription_name[each.key].result
   scope = azurerm_eventgrid_topic.topic.id
 
   retry_policy {


### PR DESCRIPTION
When topic names are long they result in subscriptions names that must be truncated (to max 24 chars) to meet Azure's name restrictions. The truncation could result in two services subscribing to the same topic ending up with the same name for their subscriptions, causing a conflict for the Event Subscription resources.

