### PR TITLE
fix(azure-tf): adds resource name to policy name

### DIFF
--- a/cloud/azure/deploytf/policy.go
+++ b/cloud/azure/deploytf/policy.go
@@ -177,7 +177,7 @@ func (a *NitricAzureTerraformProvider) Policy(stack cdktf.TerraformStack, name s
 					return err
 				}
 
-				policy.NewPolicy(stack, jsii.Sprintf("%s-%s", principal.Id.Name, roleName), &policy.PolicyConfig{
+				policy.NewPolicy(stack, jsii.Sprintf("%s-%s-%s", principal.Id.Name, roleName, resource.Id.Name), &policy.PolicyConfig{
 					ServicePrincipalId: spId,
 					Scope:              scope.Scope,
 					RoleDefinitionId:   role,


### PR DESCRIPTION
Ensures uniqueness of policy names by including the resource name in the generated name.

Fixes #792 
