### PR TITLE
ci: migrate to changelog.disable

### DIFF
--- a/cloud/aws/.goreleaser.tf.yaml
+++ b/cloud/aws/.goreleaser.tf.yaml
@@ -37,4 +37,4 @@ checksum:
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:
-  skip: true
+  disable: true

--- a/cloud/aws/.goreleaser.yaml
+++ b/cloud/aws/.goreleaser.yaml
@@ -36,4 +36,4 @@ checksum:
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:
-  skip: true
+  disable: true

--- a/cloud/azure/.goreleaser.tf.yaml
+++ b/cloud/azure/.goreleaser.tf.yaml
@@ -37,4 +37,4 @@ checksum:
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:
-  skip: true
+  disable: true

--- a/cloud/azure/.goreleaser.yaml
+++ b/cloud/azure/.goreleaser.yaml
@@ -35,4 +35,4 @@ checksum:
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:
-  skip: true
+  disable: true

--- a/cloud/gcp/.goreleaser.tf.yaml
+++ b/cloud/gcp/.goreleaser.tf.yaml
@@ -37,4 +37,4 @@ checksum:
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:
-  skip: true
+  disable: true

--- a/cloud/gcp/.goreleaser.yaml
+++ b/cloud/gcp/.goreleaser.yaml
@@ -35,4 +35,4 @@ checksum:
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION

# Description
This small PR migrates the deprecated `changelog.skip` to `changelog.disable`:
```
DEPRECATED:  changelog.skip should not be used anymore, check https://goreleaser.com/deprecations#changelogskip for more info
```
see [CI logs](https://github.com/nitrictech/nitric/actions/runs/14790378366/job/41526191924#step:5:46) for more information.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing