### PR TITLE
fix(gcp): only require a domain when websites are deployed

### DIFF
--- a/cloud/gcp/deploy/deploy.go
+++ b/cloud/gcp/deploy/deploy.go
@@ -92,6 +92,7 @@ type NitricGcpPulumiProvider struct {
 	Secrets                map[string]*secretmanager.Secret
 	DatabaseMigrationBuild map[string]*cloudrunv2.Job
 
+	EntrypointRequired bool
 	// files to upload to the website bucket
 	// The map key represents the baseUrl/directory in the bucket
 	WebsiteBuckets        map[string]*storage.Bucket
@@ -404,7 +405,10 @@ func getGCPToken(ctx *pulumi.Context) (*oauth2.Token, error) {
 }
 
 func (a *NitricGcpPulumiProvider) Post(ctx *pulumi.Context) error {
-	return a.deployEntrypoint(ctx)
+	if a.EntrypointRequired {
+		return a.deployEntrypoint(ctx)
+	}
+	return nil
 }
 
 func (a *NitricGcpPulumiProvider) Result(ctx *pulumi.Context) (pulumi.StringOutput, error) {

--- a/cloud/gcp/deploy/website.go
+++ b/cloud/gcp/deploy/website.go
@@ -315,6 +315,8 @@ func (a *NitricGcpPulumiProvider) deployEntrypoint(ctx *pulumi.Context) error {
 
 // Website - Implements the Website deployment method for the GCP provider
 func (a *NitricGcpPulumiProvider) Website(ctx *pulumi.Context, parent pulumi.Resource, name string, config *deploymentspb.Website) error {
+	a.EntrypointRequired = true
+
 	if a.GcpConfig.CdnDomain.DomainName == "" {
 		return fmt.Errorf("website deployments to GCP require a domain name to be configured in the stack file.")
 	}


### PR DESCRIPTION
Currently a domain configuration is always being checked, but it's only required when websites are enabled.