### PR TITLE
fix(sql): support auto-minor db engine version upgrades

### DIFF
--- a/cloud/aws/deploy/sql.go
+++ b/cloud/aws/deploy/sql.go
@@ -98,7 +98,7 @@ func (a *NitricAwsPulumiProvider) rds(ctx *pulumi.Context) error {
 	a.DatabaseCluster, err = rds.NewCluster(ctx, "postgresql", &rds.ClusterArgs{
 		ApplyImmediately: pulumi.Bool(true),
 		Engine:           pulumi.String(rds.EngineTypeAuroraPostgresql),
-		EngineVersion:    pulumi.String("13.16"),
+		EngineVersion:    pulumi.String("13"),
 		// TODO: limit number of availability zones
 		AvailabilityZones:                pulumi.ToStringArray(a.VpcAzs),
 		DatabaseName:                     pulumi.String("nitric"),

--- a/cloud/aws/deploytf/.nitric/modules/rds/main.tf
+++ b/cloud/aws/deploytf/.nitric/modules/rds/main.tf
@@ -68,7 +68,7 @@ resource "aws_rds_cluster" "rds_cluster" {
   cluster_identifier     = "nitric-rds-cluster"
   engine                 = "aurora-postgresql"
   engine_mode            = "provisioned"
-  engine_version         = "13.14"
+  engine_version         = "13"
   database_name          = "nitric"
   master_username        = "nitric"
   master_password        = random_password.rds_password.result


### PR DESCRIPTION
Auto-minor db engine versions are enabled by default, specifying just the major version in the deployment ensures Pulumi/Terraform don't try to roll back the engine version on subsequent deployments after an upgrade.