### PR TITLE
Add base path routing to entrypoints

### DIFF
--- a/cli/internal/simulation/simulation.go
+++ b/cli/internal/simulation/simulation.go
@@ -115,12 +115,21 @@ func (s *SimulationServer) startEntrypoints(services map[string]*service.Service
 			var proxyHandler http.Handler
 			styleColor := style.Teal
 			if spec.Type == "service" {
-				proxyHandler = serviceProxies[target.TargetName]
+				service := services[target.TargetName]
+
+				url := &url.URL{
+					Scheme: "http",
+					Host:   fmt.Sprintf("localhost:%d", service.GetPort()),
+					Path:   target.BasePath,
+				}
+
+				proxyHandler = httputil.NewSingleHostReverseProxy(url)
+
 			} else if spec.Type == "bucket" {
 				url := &url.URL{
 					Scheme: "http",
 					Host:   fmt.Sprintf("localhost:%d", s.fileServerPort),
-					Path:   fmt.Sprintf("/%s", target.TargetName),
+					Path:   strings.TrimSuffix(fmt.Sprintf("/%s/%s", target.TargetName, target.BasePath), "/"),
 				}
 				proxyHandler = httputil.NewSingleHostReverseProxy(url)
 				styleColor = style.Green

--- a/cli/pkg/schema/entrypoint.go
+++ b/cli/pkg/schema/entrypoint.go
@@ -28,5 +28,5 @@ func (e EntrypointIntent) JSONSchemaExtend(schema *jsonschema.Schema) {
 
 type Route struct {
 	TargetName string `json:"name" yaml:"name"`
-	BasePath   string `json:"base-path" yaml:"base-path"`
+	BasePath   string `json:"base-path,omitempty" yaml:"base-path,omitempty"`
 }

--- a/cli/pkg/schema/entrypoint.go
+++ b/cli/pkg/schema/entrypoint.go
@@ -28,4 +28,5 @@ func (e EntrypointIntent) JSONSchemaExtend(schema *jsonschema.Schema) {
 
 type Route struct {
 	TargetName string `json:"name" yaml:"name"`
+	BasePath   string `json:"base-path" yaml:"base-path"`
 }

--- a/engines/terraform/plugins/awscloudfront/module/main.tf
+++ b/engines/terraform/plugins/awscloudfront/module/main.tf
@@ -133,6 +133,7 @@ resource "aws_cloudfront_distribution" "distribution" {
       domain_name = origin.value.domain_name
       origin_id = "${origin.key}"
       origin_access_control_id = contains(keys(origin.value.resources), "aws_lambda_function") ? aws_cloudfront_origin_access_control.lambda_oac[0].id : contains(keys(origin.value.resources), "aws_s3_bucket") ? aws_cloudfront_origin_access_control.s3_oac[0].id : null
+      origin_path = origin.value.base_path
 
       dynamic "custom_origin_config" {
         for_each = !contains(keys(origin.value.resources), "aws_s3_bucket") ? [1] : []

--- a/engines/terraform/plugins/awscloudfront/module/variables.tf
+++ b/engines/terraform/plugins/awscloudfront/module/variables.tf
@@ -5,6 +5,7 @@ variable "nitric" {
     # A map of path to origin
     origins = map(object({
       path = string
+      base_path = string
       type = string
       domain_name = string
       id = string

--- a/engines/terraform/terraform.go
+++ b/engines/terraform/terraform.go
@@ -279,9 +279,10 @@ func (e *TerraformDeployment) resolveEntrypointNitricVar(name string, appSpec *a
 		resourcesNitricVar := hclTarget.Get(jsii.String("nitric.exports.resources"))
 
 		origins[route.TargetName] = map[string]interface{}{
-			"path": jsii.String(path),
-			"type": jsii.String(intentTarget.Type),
-			"id":   idNitricVar,
+			"path":      jsii.String(path),
+			"base_path": jsii.String(route.BasePath),
+			"type":      jsii.String(intentTarget.Type),
+			"id":        idNitricVar,
 			// Assume the output var has a http_endpoint property
 			"domain_name": domainNameNitricVar,
 			"resources":   resourcesNitricVar,


### PR DESCRIPTION
Allows subsets of application routes to be exposed via the entrypoints. This will be important for when we implement triggers so their routes can be kept clear of the main entrypoint.