### PR TITLE
Skips client generation if no client resources exist

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -42,6 +42,11 @@ var generateCmd = &cobra.Command{
 			return
 		}
 
+		if !client.SpecHasClientResources(*appSpec) {
+			fmt.Println("No client compatible resources found in application, skipping client generation")
+			return
+		}
+
 		// check if the go language flag is provided
 		if goFlag {
 			fmt.Println("Generating Go client...")

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -10,3 +10,14 @@ import (
 func GeneratePython(fs afero.Fs, appSpec schema.Application, outputDir string) error {
 	return fmt.Errorf("python SDK generation not implemented")
 }
+
+func SpecHasClientResources(appSpec schema.Application) bool {
+	for _, intent := range appSpec.GetResourceIntents() {
+		// TODO: Add other adaptable resources here.
+		if intent.GetType() == "bucket" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cli/pkg/client/go_client_template
+++ b/cli/pkg/client/go_client_template
@@ -5,7 +5,9 @@ package {{.Package}}
 import (
 	"fmt"
 
+	{{ if .Buckets }}
 	storagepb "github.com/nitrictech/nitric/proto/storage/v2"
+	{{ end }}
 
 	"github.com/nitrictech/nitric/client/go/nitric"
 	"google.golang.org/grpc"
@@ -24,7 +26,10 @@ func NewClient() (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to nitric runtime server: %w", err)
 	}
+	
+	{{ if .Buckets }}
 	storageClient := storagepb.NewStorageClient(cc)
+	{{ end }}
 
 	return &Client{
 		{{range .Buckets}}{{.PascalCase}}: nitric.NewBucket(storageClient, "{{.Unmodified}}"),


### PR DESCRIPTION
Prevents client generation when the application specification lacks compatible resources.

- Avoids unnecessary processing and potential errors by checking for client-adaptable resources (e.g., buckets) before initiating the client generation process.
- Improves efficiency by skipping client generation for applications that do not require it.