### PR TITLE
add an init command to the new cli

### DIFF
--- a/cli/cmd/nitric.go
+++ b/cli/cmd/nitric.go
@@ -22,6 +22,22 @@ func NewTemplatesCmd(injector do.Injector) *cobra.Command {
 	}
 }
 
+// NewInitCmd creates the init command
+func NewInitCmd(injector do.Injector) *cobra.Command {
+	return &cobra.Command{
+		Use:   "init",
+		Short: "Setup a new Nitric project",
+		Long:  `Setup a new Nitric project, including within existing applications`,
+		Run: func(cmd *cobra.Command, args []string) {
+			app, err := do.Invoke[*app.NitricApp](injector)
+			if err != nil {
+				cobra.CheckErr(err)
+			}
+			cobra.CheckErr(app.Init())
+		},
+	}
+}
+
 // NewNewCmd creates the new command
 func NewNewCmd(injector do.Injector) *cobra.Command {
 	var force bool

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -34,6 +34,7 @@ test, and deploy your Nitric applications.`,
 	rootCmd.AddCommand(NewAccessTokenCmd(injector))
 	rootCmd.AddCommand(NewVersionCmd(injector))
 	rootCmd.AddCommand(NewTemplatesCmd(injector))
+	rootCmd.AddCommand(NewInitCmd(injector))
 	rootCmd.AddCommand(NewNewCmd(injector))
 	rootCmd.AddCommand(NewBuildCmd(injector))
 	rootCmd.AddCommand(NewGenerateCmd(injector))

--- a/cli/pkg/app/nitric.go
+++ b/cli/pkg/app/nitric.go
@@ -22,6 +22,7 @@ import (
 	"github.com/nitrictech/nitric/cli/internal/plugins"
 	"github.com/nitrictech/nitric/cli/internal/simulation"
 	"github.com/nitrictech/nitric/cli/internal/style/colors"
+	"github.com/nitrictech/nitric/cli/internal/style/icons"
 	"github.com/nitrictech/nitric/cli/pkg/client"
 	"github.com/nitrictech/nitric/cli/pkg/files"
 	"github.com/nitrictech/nitric/cli/pkg/schema"
@@ -125,13 +126,6 @@ func (c *NitricApp) Init() error {
 		return nil
 	}
 
-	// Load Editor Prompt
-	_, loadEditRespIndex, err := tui.RunToggleSelect([]string{"Yes", "No"}, "Do you want to run the nitric editor after initializing the project?")
-	if err != nil {
-		return nil
-	}
-	runEditor := loadEditRespIndex == 0
-
 	newProject := &schema.Application{
 		Name:        name,
 		Description: description,
@@ -146,32 +140,18 @@ func (c *NitricApp) Init() error {
 	successStyle := lipgloss.NewStyle().Foreground(colors.Teal).Bold(true)
 	faint := lipgloss.NewStyle().Faint(true)
 
-	fmt.Println(successStyle.Render("\nProject initialized!"))
+	fmt.Println(successStyle.Render("\n " + icons.Check + " Project initialized!"))
 	fmt.Println(faint.Render("nitric project written to " + nitricYamlPath))
 
-	if runEditor {
-		err := c.Edit()
-		if err != nil {
-			fmt.Printf("An error occurred while running the nitric editor: %w\n", err)
-			return nil
-		}
-
-		fmt.Println("Next steps:")
-		fmt.Println("1. Finish editing your project in the nitric editor")
-		fmt.Println("2. Run", emphasize.Render("nitric build"), "to build the project for a specific platform")
-		fmt.Println()
-		fmt.Println("For more information, see the", emphasize.Render("nitric docs"), "at", emphasize.Render("https://nitric.io/docs"))
-
-	} else {
-		fmt.Println("Next steps:")
-		fmt.Println("1. Run", emphasize.Render("nitric edit"), "to start the nitric editor")
-		fmt.Println("2. Design your app's resources and deployment targets")
-		fmt.Println("3. Optionally, use", emphasize.Render("nitric generate"), "to generate the client libraries for your app")
-		fmt.Println("4. Run", emphasize.Render("nitric dev"), "to start the development server")
-		fmt.Println("5. Run", emphasize.Render("nitric build"), "to build the project for a specific platform")
-		fmt.Println()
-		fmt.Println("For more information, see the", emphasize.Render("nitric docs"), "at", emphasize.Render("https://nitric.io/docs"))
-	}
+	fmt.Println()
+	fmt.Println("Next steps:")
+	fmt.Println("1. Run", emphasize.Render("nitric edit"), "to start the nitric editor")
+	fmt.Println("2. Design your app's resources and deployment targets")
+	fmt.Println("3. Optionally, use", emphasize.Render("nitric generate"), "to generate the client libraries for your app")
+	fmt.Println("4. Run", emphasize.Render("nitric dev"), "to start the development server")
+	fmt.Println("5. Run", emphasize.Render("nitric build"), "to build the project for a specific platform")
+	fmt.Println()
+	fmt.Println("For more information, see the", emphasize.Render("nitric docs"), "at", emphasize.Render("https://nitric.io/docs"))
 
 	return nil
 }

--- a/cli/pkg/app/nitric.go
+++ b/cli/pkg/app/nitric.go
@@ -105,7 +105,6 @@ func (c *NitricApp) New(projectName string, force bool) error {
 		})
 		if err != nil || projectName == "" {
 			fmt.Println(err)
-			fmt.Println("+" + projectName + "+")
 			return nil
 		}
 	}

--- a/cli/pkg/app/nitric.go
+++ b/cli/pkg/app/nitric.go
@@ -99,8 +99,6 @@ func (c *NitricApp) Init() error {
 	fmt.Printf("Here we'll only cover the basics, use %s to continue editing the project.\n", emphasize.Render("nitric edit"))
 	fmt.Println()
 
-	fmt.Println("Press esc or ctrl+c to quit")
-
 	// Project Name Prompt
 	name, err := tui.RunTextInput("Project name:", func(input string) error {
 		if input == "" {
@@ -140,8 +138,8 @@ func (c *NitricApp) Init() error {
 	successStyle := lipgloss.NewStyle().Foreground(colors.Teal).Bold(true)
 	faint := lipgloss.NewStyle().Faint(true)
 
-	fmt.Println(successStyle.Render("\n " + icons.Check + " Project initialized!"))
-	fmt.Println(faint.Render("nitric project written to " + nitricYamlPath))
+	fmt.Println(successStyle.Render(" " + icons.Check + " Project initialized!"))
+	fmt.Println(faint.Render("   nitric project written to " + nitricYamlPath))
 
 	fmt.Println()
 	fmt.Println("Next steps:")

--- a/cli/pkg/tui/errors.go
+++ b/cli/pkg/tui/errors.go
@@ -1,0 +1,5 @@
+package tui
+
+import "errors"
+
+var ErrUserAborted = errors.New("quit")

--- a/cli/pkg/tui/select.go
+++ b/cli/pkg/tui/select.go
@@ -23,6 +23,7 @@ type Select struct {
 	style        SelectStyle
 	maxDisplayed int
 	viewCursor   int
+	quit         bool
 }
 
 const TitleAndHelpHeight = 3
@@ -103,6 +104,7 @@ func (s *Select) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			s.selected = s.cursor
 			return s, tea.Quit
 		case "q", "ctrl+c", "ctrl+\\", "esc":
+			s.quit = true
 			return s, tea.Quit
 		}
 	case tea.WindowSizeMsg:
@@ -222,6 +224,10 @@ func RunSelect(items []string, title string) (string, int, error) {
 	_, err := p.Run()
 	if err != nil {
 		return "", -1, err
+	}
+
+	if s.quit {
+		return "", -1, ErrUserAborted
 	}
 
 	selected, index := s.GetSelected()

--- a/cli/pkg/tui/textinput.go
+++ b/cli/pkg/tui/textinput.go
@@ -1,7 +1,6 @@
 package tui
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -15,6 +14,8 @@ type textInputModel struct {
 	title     string
 	style     textInputStyle
 	showError bool
+
+	quit bool
 
 	value string
 }
@@ -39,8 +40,10 @@ func (m textInputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+c", "esc", "ctrl+\\":
+			m.quit = true
 			return m, tea.Quit
 		case "enter":
+			m.textinput, _ = m.textinput.Update(msg)
 			if m.textinput.Err != nil {
 				m.showError = true
 				return m, nil
@@ -107,8 +110,11 @@ func RunTextInput(title string, validate func(string) error) (string, error) {
 	p := tea.NewProgram(model)
 	m, err := p.Run()
 	if err != nil {
-		fmt.Println("Error: " + err.Error())
 		return "", err
+	}
+
+	if m.(textInputModel).quit {
+		return "", ErrUserAborted
 	}
 
 	return m.(textInputModel).value, nil

--- a/cli/pkg/tui/toggle.go
+++ b/cli/pkg/tui/toggle.go
@@ -16,6 +16,7 @@ type ToggleSelect struct {
 	selected int
 	title    string
 	style    ToggleSelectStyle
+	quit     bool
 }
 
 // ToggleSelectStyle defines the styling for the select component
@@ -69,6 +70,7 @@ func (s *ToggleSelect) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			s.selected = s.cursor
 			return s, tea.Quit
 		case "q", "ctrl+c", "ctrl+\\", "esc":
+			s.quit = true
 			return s, tea.Quit
 		}
 	}
@@ -146,6 +148,10 @@ func RunToggleSelect(items []string, title string) (string, int, error) {
 	_, err := p.Run()
 	if err != nil {
 		return "", -1, err
+	}
+
+	if s.quit {
+		return "", -1, ErrUserAborted
 	}
 
 	selected, index := s.GetSelected()

--- a/cli/pkg/tui/toggle.go
+++ b/cli/pkg/tui/toggle.go
@@ -1,0 +1,153 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/nitrictech/nitric/cli/internal/style/colors"
+)
+
+// ToggleSelect represents a toggle select input component, e.g. yes/no or yes/no/maybe
+type ToggleSelect struct {
+	items    []string
+	cursor   int
+	selected int
+	title    string
+	style    ToggleSelectStyle
+}
+
+// ToggleSelectStyle defines the styling for the select component
+type ToggleSelectStyle struct {
+	Title    lipgloss.Style
+	Item     lipgloss.Style
+	Selected lipgloss.Style
+	Faint    lipgloss.Style
+}
+
+// NewToggleSelect creates a new toggle select component
+func NewToggleSelect(items []string, title string) *ToggleSelect {
+	return &ToggleSelect{
+		items:    items,
+		title:    title,
+		selected: -1,
+		style: ToggleSelectStyle{
+			Title: lipgloss.NewStyle().
+				Foreground(colors.Teal).
+				Bold(true),
+			Item: lipgloss.NewStyle().
+				Foreground(colors.White),
+			Selected: lipgloss.NewStyle().
+				Foreground(colors.Teal).
+				Bold(true),
+			Faint: lipgloss.NewStyle().
+				Faint(true),
+		},
+	}
+}
+
+// Init initializes the select component
+func (s *ToggleSelect) Init() tea.Cmd {
+	return nil
+}
+
+// Update handles user input and updates the component state
+func (s *ToggleSelect) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "up", "left", "k":
+			if s.cursor > 0 {
+				s.cursor--
+			}
+		case "down", "right", "j":
+			if s.cursor < len(s.items)-1 {
+				s.cursor++
+			}
+		case "enter", " ":
+			s.selected = s.cursor
+			return s, tea.Quit
+		case "q", "ctrl+c", "ctrl+\\", "esc":
+			return s, tea.Quit
+		}
+	}
+
+	return s, nil
+}
+
+// View renders the select component
+func (s *ToggleSelect) View() string {
+	if len(s.items) == 0 {
+		return "No items available"
+	}
+
+	var b strings.Builder
+
+	if s.selected != -1 {
+		return s.style.Faint.Render(s.title) + " " + s.items[s.selected] + "\n"
+	}
+
+	// Title
+	if s.title != "" {
+		b.WriteString(s.style.Title.Render(s.title))
+		b.WriteString(" ")
+	}
+
+	// Items
+	shownItems := make([]string, 0, len(s.items))
+	for i, item := range s.items {
+		itemStyle := s.style.Item
+		if s.cursor == i {
+			itemStyle = s.style.Selected
+		}
+
+		shownItems = append(shownItems, itemStyle.Render(item))
+	}
+
+	b.WriteString(strings.Join(shownItems, "/"))
+
+	return b.String()
+}
+
+// GetSelected returns the selected item and its index
+func (s *ToggleSelect) GetSelected() (string, int) {
+	if s.selected >= 0 && s.selected < len(s.items) {
+		return s.items[s.selected], s.selected
+	}
+	return "", -1
+}
+
+// SetItems updates the items in the select component
+func (s *ToggleSelect) SetItems(items []string) {
+	s.items = items
+	if s.cursor >= len(items) {
+		s.cursor = len(items) - 1
+	}
+	if s.cursor < 0 && len(items) > 0 {
+		s.cursor = 0
+	}
+}
+
+// SetTitle updates the title of the select component
+func (s *ToggleSelect) SetTitle(title string) {
+	s.title = title
+}
+
+// RunToggleSelect runs the select component and returns the selected item and index
+func RunToggleSelect(items []string, title string) (string, int, error) {
+	if len(items) == 0 {
+		return "", -1, fmt.Errorf("no items provided")
+	}
+
+	s := NewToggleSelect(items, title)
+	p := tea.NewProgram(s)
+
+	_, err := p.Run()
+	if err != nil {
+		return "", -1, err
+	}
+
+	selected, index := s.GetSelected()
+	return selected, index, nil
+}


### PR DESCRIPTION
The init command allows a user to start a new nitric project from scratch or within an existing application repository.

Closes: NIT-63

## Examples:

### Happy path:
https://github.com/user-attachments/assets/7be3aa10-3752-4d10-a3fe-f86be61b5654

### When the `nitric.yaml` already exists
https://github.com/user-attachments/assets/7356fccc-69ec-43d9-81c2-d67833175e57

