### PR TITLE
fix fullpath showing instead of cli binary name

### DIFF
--- a/cli/internal/version/version.go
+++ b/cli/internal/version/version.go
@@ -2,7 +2,6 @@ package version
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
@@ -10,8 +9,8 @@ var (
 	// Name of the product
 	ProductName = "Nitric"
 
-	// The name of the command that this process was executed as
-	CommandName = os.Args[0]
+	// The name of the binary/command, for use in help messages, e.g. "nitric version"
+	CommandName = "nitric"
 
 	// Raw is the string representation of the version. This will be replaced
 	// with the calculated version at build time.

--- a/cli/pkg/app/nitric.go
+++ b/cli/pkg/app/nitric.go
@@ -68,8 +68,7 @@ func (c *NitricApp) Templates() error {
 	templates, err := c.apiClient.GetTemplates()
 	if err != nil {
 		if errors.Is(err, api.ErrUnauthenticated) {
-			fmt.Println("Please login first, using the `login` command")
-			fmt.Printf("%+v\n", err)
+			fmt.Println("Please login first, using the", c.styles.emphasize.Render(version.GetCommand("login")), "command")
 			return nil
 		}
 


### PR DESCRIPTION
When using an alias to point at the binary file for the CLI the os.Args[0] value is a full path e.g. `/Users/you/somewhere/nitric/cli/bin/nitric`. If there is a clever way to get around this I'm open to it. Otherwise, simplicity is probably the solution and we just use a string.

Before:
<img width="726" height="37" alt="before" src="https://github.com/user-attachments/assets/f841888d-b603-4984-bd36-260385a74363" />

After:
<img width="422" height="41" alt="after" src="https://github.com/user-attachments/assets/a2ddb4da-6b5c-46c0-b63a-e9789fe2f374" />

