### PR TITLE
add --refresh option to access-token cmd

### DIFF
--- a/cli/cmd/auth.go
+++ b/cli/cmd/auth.go
@@ -43,7 +43,9 @@ func NewLogoutCmd(injector do.Injector) *cobra.Command {
 
 // NewAccessTokenCmd creates the access token command
 func NewAccessTokenCmd(injector do.Injector) *cobra.Command {
-	return &cobra.Command{
+	var refresh bool
+
+	cmd := &cobra.Command{
 		Use:   "access-token",
 		Short: "Get access token",
 		Long:  `Get the current access token.`,
@@ -52,7 +54,11 @@ func NewAccessTokenCmd(injector do.Injector) *cobra.Command {
 			if err != nil {
 				cobra.CheckErr(err)
 			}
-			app.AccessToken()
+			app.AccessToken(refresh)
 		},
 	}
+
+	cmd.Flags().BoolVarP(&refresh, "refresh", "r", false, "Retrieve a new access token, ignoring any cached tokens")
+
+	return cmd
 }

--- a/cli/internal/api/api.go
+++ b/cli/internal/api/api.go
@@ -12,7 +12,7 @@ import (
 
 type TokenProvider interface {
 	// GetAccessToken returns the access token for the user
-	GetAccessToken() (string, error)
+	GetAccessToken(forceRefresh bool) (string, error)
 }
 
 type NitricApiClient struct {
@@ -50,7 +50,7 @@ func (c *NitricApiClient) get(path string, requiresAuth bool) (*http.Response, e
 			return nil, errors.Wrap(ErrPreconditionFailed, "no token provider provided")
 		}
 
-		token, err := c.tokenProvider.GetAccessToken()
+		token, err := c.tokenProvider.GetAccessToken(false)
 		if err != nil {
 			return nil, errors.Wrap(ErrUnauthenticated, err.Error())
 		}

--- a/cli/internal/workos/workos.go
+++ b/cli/internal/workos/workos.go
@@ -66,14 +66,19 @@ func (a *WorkOSAuth) Login() (*http.User, error) {
 	return a.tokens.User, nil
 }
 
-func (a *WorkOSAuth) GetAccessToken() (string, error) {
-
+func (a *WorkOSAuth) GetAccessToken(forceRefresh bool) (string, error) {
 	if a.tokens == nil {
 		tokens, err := a.tokenStore.GetTokens()
 		if err != nil {
 			return "", fmt.Errorf("no stored tokens found, please login: %w", err)
 		}
 		a.tokens = tokens
+	}
+
+	if forceRefresh {
+		if err := a.refreshToken(); err != nil {
+			return "", fmt.Errorf("token refresh failed: %w", err)
+		}
 	}
 
 	// Decode the JWT to check if it's expired

--- a/cli/pkg/app/auth.go
+++ b/cli/pkg/app/auth.go
@@ -48,8 +48,8 @@ func (c *AuthApp) Logout() {
 }
 
 // AccessToken handles the access token command logic
-func (c *AuthApp) AccessToken() {
-	token, err := c.auth.GetAccessToken()
+func (c *AuthApp) AccessToken(forceRefresh bool) {
+	token, err := c.auth.GetAccessToken(forceRefresh)
 	if err != nil {
 		fmt.Printf("\n%s Error getting access token: %s\n", style.Red(icons.Cross), err)
 		return


### PR DESCRIPTION
Allows you to force a refresh of your access token, useful for testing when permissions have been updated to save a login/logout
