### PR TITLE
Add support for specifying a env_var_key as part of a database definition

### DIFF
--- a/cli/pkg/schema/database.go
+++ b/cli/pkg/schema/database.go
@@ -4,6 +4,8 @@ type DatabaseIntent struct {
 	Resource `json:",inline" yaml:",inline"`
 
 	Access map[string][]string `json:"access,omitempty" yaml:"access,omitempty"`
+	// The key that this database will export to services that depend on it.
+	EnvVarKey string `json:"env_var_key" yaml:"env_var_key"`
 }
 
 func (d *DatabaseIntent) GetAccess() (map[string][]string, bool) {

--- a/engines/terraform/deployment.go
+++ b/engines/terraform/deployment.go
@@ -33,6 +33,8 @@ func NewTerraformDeployment(engine *TerraformEngine, stackName string) *Terrafor
 	})
 	stack := cdktf.NewTerraformStack(app, jsii.String(stackName))
 
+	NewNilTerraformBackend(app, jsii.String("nil_backend"))
+
 	random.NewRandomProvider(stack, jsii.String("random"), &random.RandomProviderConfig{})
 
 	stackId := stringresource.NewStringResource(stack, jsii.String("stack_id"), &stringresource.StringResourceConfig{
@@ -104,10 +106,10 @@ func (td *TerraformDeployment) resolveEntrypointNitricVar(name string, appSpec *
 		resourcesNitricVar := hclTarget.Get(jsii.String("nitric.exports.resources"))
 
 		origins[route.TargetName] = map[string]interface{}{
-			"path":      jsii.String(path),
-			"base_path": jsii.String(route.BasePath),
-			"type":      jsii.String(intentTargetType),
-			"id":        idNitricVar,
+			"path":        jsii.String(path),
+			"base_path":   jsii.String(route.BasePath),
+			"type":        jsii.String(intentTargetType),
+			"id":          idNitricVar,
 			"domain_name": domainNameNitricVar,
 			"resources":   resourcesNitricVar,
 		}
@@ -186,7 +188,7 @@ func (td *TerraformDeployment) resolveService(name string, spec *app_spec_schema
 		}
 
 		idModule := cdktf.NewTerraformHclModule(td.stack, jsii.Sprintf("%s_%s_role", name, identityPlugin.Name), &cdktf.TerraformHclModuleConfig{
-			Source: jsii.String(identityPlugin.Deployment.Terraform),
+			Source:    jsii.String(identityPlugin.Deployment.Terraform),
 			Variables: &id.Properties,
 		})
 

--- a/engines/terraform/deployment.go
+++ b/engines/terraform/deployment.go
@@ -33,7 +33,7 @@ func NewTerraformDeployment(engine *TerraformEngine, stackName string) *Terrafor
 	})
 	stack := cdktf.NewTerraformStack(app, jsii.String(stackName))
 
-	NewNilTerraformBackend(app, jsii.String("nil_backend"))
+	NewNilTerraformBackend(stack, jsii.String("nil_backend"))
 
 	random.NewRandomProvider(stack, jsii.String("random"), &random.RandomProviderConfig{})
 

--- a/engines/terraform/deployment.go
+++ b/engines/terraform/deployment.go
@@ -1,0 +1,226 @@
+package terraform
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/aws/jsii-runtime-go"
+	random "github.com/cdktf/cdktf-provider-random-go/random/v11/provider"
+	"github.com/cdktf/cdktf-provider-random-go/random/v11/stringresource"
+	"github.com/hashicorp/terraform-cdk-go/cdktf"
+	app_spec_schema "github.com/nitrictech/nitric/cli/pkg/schema"
+)
+
+type TerraformDeployment struct {
+	app     cdktf.App
+	stack   cdktf.TerraformStack
+	stackId stringresource.StringResource
+	engine  *TerraformEngine
+
+	serviceIdentities map[string]map[string]interface{}
+
+	terraformResources          map[string]cdktf.TerraformHclModule
+	terraformInfraResources     map[string]cdktf.TerraformHclModule
+	terraformVariables          map[string]cdktf.TerraformVariable
+	instancedTerraformVariables map[string]map[string]cdktf.TerraformVariable
+}
+
+func NewTerraformDeployment(engine *TerraformEngine, stackName string) *TerraformDeployment {
+	app := cdktf.NewApp(&cdktf.AppConfig{
+		Outdir: jsii.String(engine.outputDir),
+	})
+	stack := cdktf.NewTerraformStack(app, jsii.String(stackName))
+
+	random.NewRandomProvider(stack, jsii.String("random"), &random.RandomProviderConfig{})
+
+	stackId := stringresource.NewStringResource(stack, jsii.String("stack_id"), &stringresource.StringResourceConfig{
+		Length:  jsii.Number(8),
+		Upper:   jsii.Bool(false),
+		Lower:   jsii.Bool(true),
+		Numeric: jsii.Bool(false),
+		Special: jsii.Bool(false),
+	})
+
+	return &TerraformDeployment{
+		app:                         app,
+		stack:                       stack,
+		stackId:                     stackId,
+		engine:                      engine,
+		terraformResources:          map[string]cdktf.TerraformHclModule{},
+		terraformInfraResources:     map[string]cdktf.TerraformHclModule{},
+		terraformVariables:          map[string]cdktf.TerraformVariable{},
+		instancedTerraformVariables: map[string]map[string]cdktf.TerraformVariable{},
+		serviceIdentities:           map[string]map[string]interface{}{},
+	}
+}
+
+func (td *TerraformDeployment) resolveInfraResource(infraName string) (cdktf.TerraformHclModule, error) {
+	resource, ok := td.engine.platform.InfraSpecs[infraName]
+	if !ok {
+		return nil, fmt.Errorf("infra resource %s not found", infraName)
+	}
+
+	if _, ok := td.terraformInfraResources[infraName]; !ok {
+		pluginRef, err := td.engine.resolvePlugin(resource)
+		if err != nil {
+			return nil, err
+		}
+
+		td.terraformInfraResources[infraName] = cdktf.NewTerraformHclModule(td.stack, jsii.String(infraName), &cdktf.TerraformHclModuleConfig{
+			Source: jsii.String(pluginRef.Deployment.Terraform),
+		})
+	}
+
+	return td.terraformInfraResources[infraName], nil
+}
+
+func (td *TerraformDeployment) resolveEntrypointNitricVar(name string, appSpec *app_spec_schema.Application, spec *app_spec_schema.EntrypointIntent) (interface{}, error) {
+	origins := map[string]interface{}{}
+	for path, route := range spec.Routes {
+		intentTarget, ok := appSpec.GetResourceIntent(route.TargetName)
+		if !ok {
+			return nil, fmt.Errorf("target %s not found", route.TargetName)
+		}
+
+		var intentTargetType string
+		switch intentTarget.(type) {
+		case *app_spec_schema.ServiceIntent:
+			intentTargetType = "service"
+		case *app_spec_schema.BucketIntent:
+			intentTargetType = "bucket"
+		default:
+			return nil, fmt.Errorf("target %s is not a service or bucket", route.TargetName)
+		}
+
+		hclTarget, ok := td.terraformResources[route.TargetName]
+		if !ok {
+			return nil, fmt.Errorf("target %s not found", route.TargetName)
+		}
+
+		domainNameNitricVar := hclTarget.Get(jsii.String("nitric.domain_name"))
+		idNitricVar := hclTarget.Get(jsii.String("nitric.id"))
+		resourcesNitricVar := hclTarget.Get(jsii.String("nitric.exports.resources"))
+
+		origins[route.TargetName] = map[string]interface{}{
+			"path":      jsii.String(path),
+			"base_path": jsii.String(route.BasePath),
+			"type":      jsii.String(intentTargetType),
+			"id":        idNitricVar,
+			"domain_name": domainNameNitricVar,
+			"resources":   resourcesNitricVar,
+		}
+	}
+
+	nitricVar := map[string]interface{}{
+		"name":     jsii.String(name),
+		"stack_id": td.stackId.Result(),
+		"origins":  origins,
+	}
+
+	return nitricVar, nil
+}
+
+func (td *TerraformDeployment) resolveService(name string, spec *app_spec_schema.ServiceIntent, resourceSpec *ServiceBlueprint, plug *ResourcePluginManifest) (*NitricServiceVariables, error) {
+	var imageVars *map[string]interface{} = nil
+
+	pluginManifest, err := td.engine.resolvePluginsForService(plug)
+	if err != nil {
+		return nil, err
+	}
+
+	pluginManifestBytes, err := json.Marshal(pluginManifest)
+	if err != nil {
+		return nil, err
+	}
+
+	var schedules map[string]NitricServiceSchedule = nil
+	if len(schedules) > 0 && !slices.Contains(plug.Capabilities, "schedules") {
+		return nil, fmt.Errorf("service %s has schedules but the plugin %s does not support schedules", name, plug.Name)
+	} else {
+		schedules = map[string]NitricServiceSchedule{}
+	}
+
+	for triggerName, trigger := range spec.Triggers {
+		if trigger.Schedule == nil {
+			continue
+		}
+
+		schedules[triggerName] = NitricServiceSchedule{
+			CronExpression: jsii.String(trigger.Schedule.CronExpression),
+			Path:           jsii.String(trigger.Path),
+		}
+	}
+
+	if spec.Container.Image != nil {
+		imageVars = &map[string]interface{}{
+			"image_id": jsii.String(spec.Container.Image.ID),
+			"tag":      jsii.String(name),
+			"args":     map[string]*string{"PLUGIN_DEFINITION": jsii.String(string(pluginManifestBytes))},
+		}
+	} else if spec.Container.Docker != nil {
+		args := map[string]*string{"PLUGIN_DEFINITION": jsii.String(string(pluginManifestBytes))}
+		for k, v := range spec.Container.Docker.Args {
+			args[k] = jsii.String(v)
+		}
+
+		imageVars = &map[string]interface{}{
+			"build_context": jsii.String(spec.Container.Docker.Context),
+			"dockerfile":    jsii.String(spec.Container.Docker.Dockerfile),
+			"tag":           jsii.String(name),
+			"args":          args,
+		}
+	}
+
+	imageModule := cdktf.NewTerraformHclModule(td.stack, jsii.Sprintf("%s_image", name), &cdktf.TerraformHclModuleConfig{
+		Source:    jsii.String(imageModuleRef),
+		Variables: imageVars,
+	})
+
+	identityModuleOutputs := map[string]interface{}{}
+	for _, id := range resourceSpec.Identities {
+		identityPlugin, err := td.engine.resolveIdentityPlugin(&id)
+		if err != nil {
+			return nil, err
+		}
+
+		idModule := cdktf.NewTerraformHclModule(td.stack, jsii.Sprintf("%s_%s_role", name, identityPlugin.Name), &cdktf.TerraformHclModuleConfig{
+			Source: jsii.String(identityPlugin.Deployment.Terraform),
+			Variables: &id.Properties,
+		})
+
+		idModule.Set(jsii.String("nitric"), map[string]interface{}{
+			"name":     jsii.String(name),
+			"stack_id": td.stackId.Result(),
+		})
+
+		identityModuleOutputs[identityPlugin.IdentityType] = idModule.Get(jsii.String("nitric"))
+	}
+
+	for _, requiredIdentity := range plug.RequiredIdentities {
+		providedIdentities := slices.Collect(maps.Keys(identityModuleOutputs))
+		if ok := slices.Contains(providedIdentities, requiredIdentity); !ok {
+			return nil, fmt.Errorf("service %s is missing identity %s, required by plugin %s, provided identities were %s", name, requiredIdentity, plug.Name, providedIdentities)
+		}
+	}
+
+	nitricVar := &NitricServiceVariables{
+		NitricVariables: NitricVariables{
+			Name: jsii.String(name),
+		},
+		Schedules:  &schedules,
+		ImageId:    imageModule.GetString(jsii.String("image_id")),
+		Identities: &identityModuleOutputs,
+		StackId:    td.stackId.Result(),
+		Env:        &spec.Env,
+	}
+
+	td.serviceIdentities[name] = identityModuleOutputs
+
+	return nitricVar, nil
+}
+
+func (td *TerraformDeployment) Synth() {
+	td.app.Synth()
+}

--- a/engines/terraform/resolve.go
+++ b/engines/terraform/resolve.go
@@ -1,0 +1,124 @@
+package terraform
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/jsii-runtime-go"
+	"github.com/hashicorp/terraform-cdk-go/cdktf"
+)
+
+func SpecReferenceFromToken(token string) (*SpecReference, error) {
+	contents, ok := extractTokenContents(token)
+	if !ok {
+		return nil, fmt.Errorf("invalid token format")
+	}
+
+	parts := strings.Split(contents, ".")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("invalid token format")
+	}
+
+	return &SpecReference{
+		Source: parts[0],
+		Path:   parts[1:],
+	}, nil
+}
+
+func (td *TerraformDeployment) resolveValue(intentName string, value interface{}) (interface{}, error) {
+	switch v := value.(type) {
+	case string:
+		specRef, err := SpecReferenceFromToken(v)
+		if err != nil {
+			return v, nil
+		}
+
+		if specRef.Source == "infra" {
+			refName := specRef.Path[0]
+			propertyName := specRef.Path[1]
+
+			infraResource, err := td.resolveInfraResource(refName)
+			if err != nil {
+				return nil, err
+			}
+			return infraResource.Get(jsii.String(propertyName)), nil
+		} else if specRef.Source == "self" {
+			tfVariable, ok := td.instancedTerraformVariables[intentName][specRef.Path[0]]
+			if !ok {
+				return nil, fmt.Errorf("Variable %s does not exist for provided blueprint", specRef.Path[0])
+			}
+			return tfVariable.Value(), nil
+		} else if specRef.Source == "var" {
+			tfVariable, ok := td.terraformVariables[specRef.Path[0]]
+			if !ok {
+				return nil, fmt.Errorf("Variable %s does not exist for this platform", specRef.Path[0])
+			}
+			return tfVariable.Value(), nil
+		}
+		return v, nil
+
+	case map[string]interface{}:
+		result := make(map[string]interface{})
+		for key, val := range v {
+			resolvedVal, err := td.resolveValue(intentName, val)
+			if err != nil {
+				return nil, err
+			}
+			result[key] = resolvedVal
+		}
+		return result, nil
+
+	case []interface{}:
+		result := make([]interface{}, len(v))
+		for i, val := range v {
+			resolvedVal, err := td.resolveValue(intentName, val)
+			if err != nil {
+				return nil, err
+			}
+			result[i] = resolvedVal
+		}
+		return result, nil
+
+	default:
+		return v, nil
+	}
+}
+
+func (td *TerraformDeployment) resolveTokensForModule(intentName string, resource *ResourceBlueprint, module cdktf.TerraformHclModule) error {
+	for property, value := range resource.Properties {
+		resolvedValue, err := td.resolveValue(intentName, value)
+		if err != nil {
+			return err
+		}
+		module.Set(jsii.String(property), resolvedValue)
+	}
+
+	return nil
+}
+
+func (td *TerraformDeployment) resolveDependencies(resource *ResourceBlueprint, module cdktf.TerraformHclModule) error {
+	if len(resource.DependsOn) == 0 {
+		return nil
+	}
+
+	dependsOnResources := []*string{}
+	for _, dependsOn := range resource.DependsOn {
+		specRef, err := SpecReferenceFromToken(dependsOn)
+		if err != nil {
+			return err
+		}
+
+		if specRef.Source != "infra" {
+			return fmt.Errorf("depends_on can only reference infra resources")
+		}
+
+		if _, ok := td.terraformInfraResources[specRef.Path[0]]; !ok {
+			continue
+		}
+
+		moduleId := fmt.Sprintf("module.%s", *td.terraformInfraResources[specRef.Path[0]].Node().Id())
+		dependsOnResources = append(dependsOnResources, jsii.String(moduleId))
+	}
+	module.SetDependsOn(&dependsOnResources)
+	return nil
+}

--- a/engines/terraform/resource_handler.go
+++ b/engines/terraform/resource_handler.go
@@ -13,6 +13,11 @@ import (
 func (e *TerraformEngine) resolvePluginsForService(servicePlugin *ResourcePluginManifest) (*plugin.PluginDefinition, error) {
 	gets := []string{}
 
+	// Check if Runtime is nil to prevent panic
+	if servicePlugin.Runtime == nil {
+		return nil, fmt.Errorf("service plugin %s has no runtime configuration", servicePlugin.Name)
+	}
+
 	pluginDef := &plugin.PluginDefinition{
 		Service: plugin.GoPlugin{
 			Alias:  "svcPlugin",
@@ -237,4 +242,3 @@ func (td *TerraformDeployment) processDatabaseResources(appSpec *app_spec_schema
 
 	return serviceEnvs, nil
 }
-

--- a/engines/terraform/resource_handler.go
+++ b/engines/terraform/resource_handler.go
@@ -1,0 +1,240 @@
+package terraform
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/jsii-runtime-go"
+	"github.com/hashicorp/terraform-cdk-go/cdktf"
+	app_spec_schema "github.com/nitrictech/nitric/cli/pkg/schema"
+	"github.com/nitrictech/nitric/server/plugin"
+)
+
+func (e *TerraformEngine) resolvePluginsForService(servicePlugin *ResourcePluginManifest) (*plugin.PluginDefinition, error) {
+	gets := []string{}
+
+	pluginDef := &plugin.PluginDefinition{
+		Service: plugin.GoPlugin{
+			Alias:  "svcPlugin",
+			Name:   "default",
+			Import: strings.Split(servicePlugin.Runtime.GoModule, "@")[0],
+		},
+	}
+	gets = append(gets, servicePlugin.Runtime.GoModule)
+
+	storagePlugins, err := e.GetPluginManifestsForType("bucket")
+	if err != nil {
+		return nil, err
+	}
+
+	for name, plug := range storagePlugins {
+		pluginDef.Storage = append(pluginDef.Storage, plugin.GoPlugin{
+			Alias:  fmt.Sprintf("storage_%s", name),
+			Name:   name,
+			Import: strings.Split(plug.Runtime.GoModule, "@")[0],
+		})
+		gets = append(gets, plug.Runtime.GoModule)
+	}
+
+	pluginDef.Gets = gets
+
+	return pluginDef, nil
+}
+
+func (td *TerraformDeployment) processServiceIdentities(appSpec *app_spec_schema.Application) (map[string]*NitricServiceVariables, error) {
+	serviceInputs := map[string]*NitricServiceVariables{}
+
+	for intentName, serviceIntent := range appSpec.ServiceIntents {
+		spec, err := td.engine.platform.GetServiceBlueprint(serviceIntent.GetSubType())
+		if err != nil {
+			return nil, fmt.Errorf("could not find platform type for %s.%s: %w", serviceIntent.GetType(), serviceIntent.GetSubType(), err)
+		}
+		plug, err := td.engine.resolvePlugin(spec.ResourceBlueprint)
+		if err != nil {
+			return nil, err
+		}
+
+		nitricVar, err := td.resolveService(intentName, serviceIntent, spec, plug)
+		if err != nil {
+			return nil, err
+		}
+
+		serviceInputs[intentName] = nitricVar
+	}
+
+	return serviceInputs, nil
+}
+
+func (td *TerraformDeployment) processServiceResources(appSpec *app_spec_schema.Application, serviceInputs map[string]*NitricServiceVariables, serviceEnvs map[string][]interface{}) error {
+	for intentName, serviceIntent := range appSpec.ServiceIntents {
+		spec, err := td.engine.platform.GetResourceBlueprint(serviceIntent.GetType(), serviceIntent.GetSubType())
+		if err != nil {
+			return fmt.Errorf("could not find platform type for %s.%s: %w", serviceIntent.GetType(), serviceIntent.GetSubType(), err)
+		}
+		plug, err := td.engine.resolvePlugin(spec)
+		if err != nil {
+			return err
+		}
+
+		nitricVar := serviceInputs[intentName]
+		origEnv := nitricVar.Env
+
+		mergedEnv := serviceEnvs[intentName]
+		allEnv := append(mergedEnv, origEnv)
+		nitricVar.Env = cdktf.Fn_Merge(&allEnv)
+
+		td.createVariablesForIntent(intentName, spec)
+
+		td.terraformResources[intentName] = cdktf.NewTerraformHclModule(td.stack, jsii.String(intentName), &cdktf.TerraformHclModuleConfig{
+			Source: jsii.String(plug.Deployment.Terraform),
+			Variables: &map[string]interface{}{
+				"nitric": nitricVar,
+			},
+		})
+	}
+
+	return nil
+}
+
+func (td *TerraformDeployment) processBucketResources(appSpec *app_spec_schema.Application) (map[string][]interface{}, error) {
+	serviceEnvs := map[string][]interface{}{}
+
+	for intentName, bucketIntent := range appSpec.BucketIntents {
+		contentPath := ""
+		if bucketIntent != nil {
+			contentPath = bucketIntent.ContentPath
+		}
+
+		spec, err := td.engine.platform.GetResourceBlueprint(bucketIntent.GetType(), bucketIntent.GetSubType())
+		if err != nil {
+			return nil, fmt.Errorf("could not find platform type for %s.%s: %w", bucketIntent.GetType(), bucketIntent.GetSubType(), err)
+		}
+		plug, err := td.engine.resolvePlugin(spec)
+		if err != nil {
+			return nil, err
+		}
+
+		servicesInput := map[string]any{}
+		if access, ok := bucketIntent.GetAccess(); ok {
+			for serviceName, actions := range access {
+				idMap, ok := td.serviceIdentities[serviceName]
+				if !ok {
+					return nil, fmt.Errorf("could not give access to bucket %s: service %s not found", intentName, serviceName)
+				}
+
+				servicesInput[serviceName] = map[string]interface{}{
+					"actions":    jsii.Strings(actions...),
+					"identities": idMap,
+				}
+			}
+		}
+
+		nitricVar := map[string]any{
+			"name":         intentName,
+			"stack_id":     td.stackId.Result(),
+			"content_path": contentPath,
+			"services":     servicesInput,
+		}
+
+		td.createVariablesForIntent(intentName, spec)
+
+		td.terraformResources[intentName] = cdktf.NewTerraformHclModule(td.stack, jsii.String(intentName), &cdktf.TerraformHclModuleConfig{
+			Source: jsii.String(plug.Deployment.Terraform),
+			Variables: &map[string]interface{}{
+				"nitric": nitricVar,
+			},
+		})
+
+		// Collect environment variables that buckets export to services
+		for serviceName := range td.serviceIdentities {
+			env := cdktf.Fn_Try(&[]interface{}{td.terraformResources[intentName].Get(jsii.Sprintf("nitric.exports.services.%s.env", serviceName)), map[string]interface{}{}})
+			serviceEnvs[serviceName] = append(serviceEnvs[serviceName], env)
+		}
+	}
+
+	return serviceEnvs, nil
+}
+
+func (td *TerraformDeployment) processEntrypointResources(appSpec *app_spec_schema.Application) error {
+	for intentName, entrypointIntent := range appSpec.EntrypointIntents {
+		spec, err := td.engine.platform.GetResourceBlueprint(entrypointIntent.GetType(), entrypointIntent.GetSubType())
+		if err != nil {
+			return fmt.Errorf("could not find platform type for %s.%s: %w", entrypointIntent.GetType(), entrypointIntent.GetSubType(), err)
+		}
+		plug, err := td.engine.resolvePlugin(spec)
+		if err != nil {
+			return err
+		}
+
+		nitricVar, err := td.resolveEntrypointNitricVar(intentName, appSpec, entrypointIntent)
+		if err != nil {
+			return err
+		}
+
+		td.createVariablesForIntent(intentName, spec)
+
+		td.terraformResources[intentName] = cdktf.NewTerraformHclModule(td.stack, jsii.String(intentName), &cdktf.TerraformHclModuleConfig{
+			Source: jsii.String(plug.Deployment.Terraform),
+			Variables: &map[string]interface{}{
+				"nitric": nitricVar,
+			},
+		})
+	}
+
+	return nil
+}
+
+func (td *TerraformDeployment) processDatabaseResources(appSpec *app_spec_schema.Application) (map[string][]interface{}, error) {
+	serviceEnvs := map[string][]interface{}{}
+
+	for intentName, databaseIntent := range appSpec.DatabaseIntents {
+		spec, err := td.engine.platform.GetResourceBlueprint(databaseIntent.GetType(), databaseIntent.GetSubType())
+		if err != nil {
+			return nil, fmt.Errorf("could not find platform type for %s.%s: %w", databaseIntent.GetType(), databaseIntent.GetSubType(), err)
+		}
+		plug, err := td.engine.resolvePlugin(spec)
+		if err != nil {
+			return nil, err
+		}
+
+		servicesInput := map[string]any{}
+		if access, ok := databaseIntent.GetAccess(); ok {
+			for serviceName, actions := range access {
+				idMap, ok := td.serviceIdentities[serviceName]
+				if !ok {
+					return nil, fmt.Errorf("could not give access to database %s: service %s not found", intentName, serviceName)
+				}
+
+				servicesInput[serviceName] = map[string]interface{}{
+					"actions":    jsii.Strings(actions...),
+					"identities": idMap,
+				}
+			}
+		}
+
+		nitricVar := map[string]any{
+			"name":        intentName,
+			"stack_id":    td.stackId.Result(),
+			"services":    servicesInput,
+			"env_var_key": databaseIntent.EnvVarKey,
+		}
+
+		td.createVariablesForIntent(intentName, spec)
+
+		td.terraformResources[intentName] = cdktf.NewTerraformHclModule(td.stack, jsii.String(intentName), &cdktf.TerraformHclModuleConfig{
+			Source: jsii.String(plug.Deployment.Terraform),
+			Variables: &map[string]interface{}{
+				"nitric": nitricVar,
+			},
+		})
+
+		// Collect environment variables that databases export to services
+		for serviceName := range td.serviceIdentities {
+			env := cdktf.Fn_Try(&[]interface{}{td.terraformResources[intentName].Get(jsii.Sprintf("nitric.exports.services.%s.env", serviceName)), map[string]interface{}{}})
+			serviceEnvs[serviceName] = append(serviceEnvs[serviceName], env)
+		}
+	}
+
+	return serviceEnvs, nil
+}
+

--- a/engines/terraform/terraform.go
+++ b/engines/terraform/terraform.go
@@ -5,18 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"maps"
 	"path/filepath"
-	"slices"
-	"strings"
 
-	"github.com/aws/jsii-runtime-go"
-	random "github.com/cdktf/cdktf-provider-random-go/random/v11/provider"
-	"github.com/cdktf/cdktf-provider-random-go/random/v11/stringresource"
-	"github.com/hashicorp/terraform-cdk-go/cdktf"
 	app_spec_schema "github.com/nitrictech/nitric/cli/pkg/schema"
 	"github.com/nitrictech/nitric/engines"
-	"github.com/nitrictech/nitric/server/plugin"
 )
 
 type TerraformEngine struct {
@@ -26,25 +18,9 @@ type TerraformEngine struct {
 	outputDir string
 }
 
-type TerraformDeployment struct {
-	app     cdktf.App
-	stack   cdktf.TerraformStack
-	stackId stringresource.StringResource
-	engine  *TerraformEngine
-
-	serviceIdentities map[string]map[string]interface{}
-
-	terraformResources          map[string]cdktf.TerraformHclModule
-	terraformInfraResources     map[string]cdktf.TerraformHclModule
-	terraformVariables          map[string]cdktf.TerraformVariable
-	instancedTerraformVariables map[string]map[string]cdktf.TerraformVariable
-}
-
 type SpecReference struct {
-	// var/infra/etc
 	Source string
-	// simple key for var or path for infra e.g. vpc.arn
-	Path []string
+	Path   []string
 }
 
 func (e *TerraformEngine) resolveIdentityPlugin(blueprint *ResourceBlueprint) (*IdentityPluginManifest, error) {
@@ -82,602 +58,64 @@ func (e *TerraformEngine) GetPluginManifestsForType(typ string) (map[string]*Res
 	return manifests, nil
 }
 
-func SpecReferenceFromToken(token string) (*SpecReference, error) {
-	contents, ok := extractTokenContents(token)
-	if !ok {
-		return nil, fmt.Errorf("invalid token format")
-	}
-
-	parts := strings.Split(contents, ".")
-	if len(parts) < 2 {
-		return nil, fmt.Errorf("invalid token format")
-	}
-
-	return &SpecReference{
-		Source: parts[0],
-		Path:   parts[1:],
-	}, nil
-}
-
-func (tf *TerraformDeployment) resolveDependencies(resource *ResourceBlueprint, module cdktf.TerraformHclModule) error {
-	if len(resource.DependsOn) == 0 {
-		return nil
-	}
-
-	dependsOnResources := []*string{}
-	for _, dependsOn := range resource.DependsOn {
-		specRef, err := SpecReferenceFromToken(dependsOn)
-		if err != nil {
-			return err
-		}
-
-		if specRef.Source != "infra" {
-			return fmt.Errorf("depends_on can only reference infra resources")
-		}
-
-		if _, ok := tf.terraformInfraResources[specRef.Path[0]]; !ok {
-			// Infra resource has not already been resolved so this dependency won't exist at all
-			continue
-		}
-
-		moduleId := fmt.Sprintf("module.%s", *tf.terraformInfraResources[specRef.Path[0]].Node().Id())
-		dependsOnResources = append(dependsOnResources, jsii.String(moduleId))
-	}
-	module.SetDependsOn(&dependsOnResources)
-	return nil
-}
-
-func (tf *TerraformDeployment) resolveInfraResource(infraName string) (cdktf.TerraformHclModule, error) {
-	resource, ok := tf.engine.platform.InfraSpecs[infraName]
-	if !ok {
-		return nil, fmt.Errorf("infra resource %s not found", infraName)
-	}
-
-	if _, ok := tf.terraformInfraResources[infraName]; !ok {
-		pluginRef, err := tf.engine.resolvePlugin(resource)
-		if err != nil {
-			return nil, err
-		}
-
-		tf.terraformInfraResources[infraName] = cdktf.NewTerraformHclModule(tf.stack, jsii.String(infraName), &cdktf.TerraformHclModuleConfig{
-			Source: jsii.String(pluginRef.Deployment.Terraform),
-		})
-	}
-
-	return tf.terraformInfraResources[infraName], nil
-}
-
-func (tf *TerraformDeployment) resolveValue(intentName string, value interface{}) (interface{}, error) {
-	switch v := value.(type) {
-	case string:
-		// Handle token resolution for strings
-		specRef, err := SpecReferenceFromToken(v)
-		if err != nil {
-			return v, nil // Return original value if not a token
-		}
-
-		if specRef.Source == "infra" {
-			refName := specRef.Path[0]
-			propertyName := specRef.Path[1]
-
-			infraResource, err := tf.resolveInfraResource(refName)
-			if err != nil {
-				return nil, err
-			}
-			// map the variable output to the infra resource
-			return infraResource.Get(jsii.String(propertyName)), nil
-		} else if specRef.Source == "self" {
-			tfVariable, ok := tf.instancedTerraformVariables[intentName][specRef.Path[0]]
-			if !ok {
-				return nil, fmt.Errorf("Variable %s does not exist for provided blueprint", specRef.Path[0])
-			}
-			return tfVariable.Value(), nil
-		} else if specRef.Source == "var" {
-			tfVariable, ok := tf.terraformVariables[specRef.Path[0]]
-			if !ok {
-				return nil, fmt.Errorf("Variable %s does not exist for this platform", specRef.Path[0])
-			}
-			return tfVariable.Value(), nil
-		}
-		return v, nil
-
-	case map[string]interface{}:
-		// Recursively process map values
-		result := make(map[string]interface{})
-		for key, val := range v {
-			resolvedVal, err := tf.resolveValue(intentName, val)
-			if err != nil {
-				return nil, err
-			}
-			result[key] = resolvedVal
-		}
-		return result, nil
-
-	case []interface{}:
-		// Recursively process slice values
-		result := make([]interface{}, len(v))
-		for i, val := range v {
-			resolvedVal, err := tf.resolveValue(intentName, val)
-			if err != nil {
-				return nil, err
-			}
-			result[i] = resolvedVal
-		}
-		return result, nil
-
-	default:
-		// Return primitive values as is
-		return v, nil
-	}
-}
-
-func (tf *TerraformDeployment) resolveTokensForModule(intentName string, resource *ResourceBlueprint, module cdktf.TerraformHclModule) error {
-	for property, value := range resource.Properties {
-		resolvedValue, err := tf.resolveValue(intentName, value)
-		if err != nil {
-			return err
-		}
-		module.Set(jsii.String(property), resolvedValue)
-	}
-
-	return nil
-}
-
-func NewTerraformDeployment(engine *TerraformEngine, stackName string) *TerraformDeployment {
-	app := cdktf.NewApp(&cdktf.AppConfig{
-		Outdir: jsii.String(engine.outputDir),
-	})
-
-	stack := cdktf.NewTerraformStack(app, jsii.String(stackName))
-
-	// Create a new nil backend for the stack
-	NewNilTerraformBackend(stack, jsii.String("nil_backend"))
-
-	random.NewRandomProvider(stack, jsii.String("random"), &random.RandomProviderConfig{})
-
-	stackId := stringresource.NewStringResource(stack, jsii.String("stack_id"), &stringresource.StringResourceConfig{
-		Length:  jsii.Number(8),
-		Upper:   jsii.Bool(false),
-		Lower:   jsii.Bool(true),
-		Numeric: jsii.Bool(false),
-		Special: jsii.Bool(false),
-	})
-
-	return &TerraformDeployment{
-		app:                         app,
-		stack:                       stack,
-		stackId:                     stackId,
-		engine:                      engine,
-		terraformResources:          map[string]cdktf.TerraformHclModule{},
-		terraformInfraResources:     map[string]cdktf.TerraformHclModule{},
-		terraformVariables:          map[string]cdktf.TerraformVariable{},
-		instancedTerraformVariables: map[string]map[string]cdktf.TerraformVariable{},
-		serviceIdentities:           map[string]map[string]interface{}{},
-	}
-}
-
-func (e *TerraformEngine) resolvePluginsForService(servicePlugin *ResourcePluginManifest) (*plugin.PluginDefinition, error) {
-	// TODO: Map platform resource plugins to the service plugin
-	gets := []string{}
-
-	// Check if Runtime is nil to prevent panic
-	if servicePlugin.Runtime == nil {
-		return nil, fmt.Errorf("service plugin %s has no runtime configuration", servicePlugin.Name)
-	}
-
-	pluginDef := &plugin.PluginDefinition{
-		Service: plugin.GoPlugin{
-			Alias:  "svcPlugin",
-			Name:   "default",
-			Import: strings.Split(servicePlugin.Runtime.GoModule, "@")[0],
-		},
-	}
-	gets = append(gets, servicePlugin.Runtime.GoModule)
-
-	// FIXME: This add all storage plugins without regard to actually requiring access
-	storagePlugins, err := e.GetPluginManifestsForType("bucket")
-	if err != nil {
-		return nil, err
-	}
-
-	// Add storage plugins to the runtime
-	for name, plug := range storagePlugins {
-		pluginDef.Storage = append(pluginDef.Storage, plugin.GoPlugin{
-			Alias:  fmt.Sprintf("storage_%s", name),
-			Name:   name,
-			Import: strings.Split(plug.Runtime.GoModule, "@")[0],
-		})
-		gets = append(gets, plug.Runtime.GoModule)
-	}
-
-	pluginDef.Gets = gets
-
-	return pluginDef, nil
-}
-
-var entrypointOriginTypes = []string{"service", "bucket"}
-
-func (e *TerraformDeployment) resolveEntrypointNitricVar(name string, appSpec *app_spec_schema.Application, spec *app_spec_schema.EntrypointIntent) (interface{}, error) {
-	origins := map[string]interface{}{}
-	for path, route := range spec.Routes {
-		intentTarget, ok := appSpec.GetResourceIntent(route.TargetName)
-		if !ok {
-			return nil, fmt.Errorf("target %s not found", route.TargetName)
-		}
-
-		var intentTargetType string
-		switch intentTarget.(type) {
-		case *app_spec_schema.ServiceIntent:
-			intentTargetType = "service"
-		case *app_spec_schema.BucketIntent:
-			intentTargetType = "bucket"
-		default:
-			return nil, fmt.Errorf("target %s is not a service or bucket", route.TargetName)
-		}
-
-		hclTarget, ok := e.terraformResources[route.TargetName]
-		if !ok {
-			return nil, fmt.Errorf("target %s not found", route.TargetName)
-		}
-
-		domainNameNitricVar := hclTarget.Get(jsii.String("nitric.domain_name"))
-		idNitricVar := hclTarget.Get(jsii.String("nitric.id"))
-		resourcesNitricVar := hclTarget.Get(jsii.String("nitric.exports.resources"))
-
-		origins[route.TargetName] = map[string]interface{}{
-			"path":      jsii.String(path),
-			"base_path": jsii.String(route.BasePath),
-			"type":      jsii.String(intentTargetType),
-			"id":        idNitricVar,
-			// Assume the output var has a http_endpoint property
-			"domain_name": domainNameNitricVar,
-			"resources":   resourcesNitricVar,
-		}
-	}
-
-	// Build the origins map
-	nitricVar := map[string]interface{}{
-		"name":     jsii.String(name),
-		"stack_id": e.stackId.Result(),
-		"origins":  origins,
-	}
-
-	return nitricVar, nil
-}
-
-func (e *TerraformDeployment) resolveService(name string, spec *app_spec_schema.ServiceIntent, resourceSpec *ServiceBlueprint, plug *ResourcePluginManifest) (*NitricServiceVariables, error) {
-	// Map the nitric variable
-	var imageVars *map[string]interface{} = nil
-
-	pluginManifest, err := e.engine.resolvePluginsForService(plug)
-	if err != nil {
-		return nil, err
-	}
-
-	pluginManifestBytes, err := json.Marshal(pluginManifest)
-	if err != nil {
-		return nil, err
-	}
-
-	var schedules map[string]NitricServiceSchedule = nil
-	if len(schedules) > 0 && !slices.Contains(plug.Capabilities, "schedules") {
-		return nil, fmt.Errorf("service %s has schedules but the plugin %s does not support schedules", name, plug.Name)
-	} else {
-		schedules = map[string]NitricServiceSchedule{}
-	}
-
-	for triggerName, trigger := range spec.Triggers {
-		if trigger.Schedule == nil {
-			continue
-		}
-
-		schedules[triggerName] = NitricServiceSchedule{
-			CronExpression: jsii.String(trigger.Schedule.CronExpression),
-			Path:           jsii.String(trigger.Path),
-		}
-	}
-
-	if spec.Container.Image != nil {
-		imageVars = &map[string]interface{}{
-			"image_id": jsii.String(spec.Container.Image.ID),
-			"tag":      jsii.String(name),
-			"args":     map[string]*string{"PLUGIN_DEFINITION": jsii.String(string(pluginManifestBytes))},
-		}
-	} else if spec.Container.Docker != nil {
-		// merge args
-		args := map[string]*string{"PLUGIN_DEFINITION": jsii.String(string(pluginManifestBytes))}
-		for k, v := range spec.Container.Docker.Args {
-			args[k] = jsii.String(v)
-		}
-
-		imageVars = &map[string]interface{}{
-			"build_context": jsii.String(spec.Container.Docker.Context),
-			"dockerfile":    jsii.String(spec.Container.Docker.Dockerfile),
-			"tag":           jsii.String(name),
-			"args":          args,
-		}
-	}
-
-	imageModule := cdktf.NewTerraformHclModule(e.stack, jsii.Sprintf("%s_image", name), &cdktf.TerraformHclModuleConfig{
-		Source:    jsii.String(imageModuleRef),
-		Variables: imageVars,
-	})
-
-	identityModuleOutputs := map[string]interface{}{}
-	for _, id := range resourceSpec.Identities {
-		identityPlugin, err := e.engine.resolveIdentityPlugin(&id)
-		if err != nil {
-			return nil, err
-		}
-
-		idModule := cdktf.NewTerraformHclModule(e.stack, jsii.Sprintf("%s_%s_role", name, identityPlugin.Name), &cdktf.TerraformHclModuleConfig{
-			Source: jsii.String(identityPlugin.Deployment.Terraform),
-			// TODO: Properly resolve tokens here
-			Variables: &id.Properties,
-		})
-
-		idModule.Set(jsii.String("nitric"), map[string]interface{}{
-			"name":     jsii.String(name),
-			"stack_id": e.stackId.Result(),
-		})
-
-		identityModuleOutputs[identityPlugin.IdentityType] = idModule.Get(jsii.String("nitric"))
-	}
-
-	for _, requiredIdentity := range plug.RequiredIdentities {
-		providedIdentities := slices.Collect(maps.Keys(identityModuleOutputs))
-		if ok := slices.Contains(providedIdentities, requiredIdentity); !ok {
-			return nil, fmt.Errorf("service %s is missing identity %s, required by plugin %s, provided identities were %s", name, requiredIdentity, plug.Name, providedIdentities)
-		}
-	}
-
-	// Create this services identities
-	nitricVar := &NitricServiceVariables{
-		NitricVariables: NitricVariables{
-			Name: jsii.String(name),
-		},
-		Schedules:  &schedules,
-		ImageId:    imageModule.GetString(jsii.String("image_id")),
-		Identities: &identityModuleOutputs,
-		StackId:    e.stackId.Result(),
-		Env:        &spec.Env,
-	}
-
-	e.serviceIdentities[name] = identityModuleOutputs
-
-	return nitricVar, nil
-}
-
-func (e *TerraformDeployment) createVariablesForIntent(intentName string, spec *ResourceBlueprint) {
-	for varName, variable := range spec.Variables {
-		if e.instancedTerraformVariables[intentName] == nil {
-			e.instancedTerraformVariables[intentName] = make(map[string]cdktf.TerraformVariable)
-		}
-
-		e.instancedTerraformVariables[intentName][varName] = cdktf.NewTerraformVariable(e.stack, jsii.Sprintf("%s_%s", intentName, varName), &cdktf.TerraformVariableConfig{
-			Description: jsii.String(variable.Description),
-			Type:        jsii.String(variable.Type),
-			// TODO: Possibly resolve a token?
-			Default: variable.Default,
-		})
-	}
-}
-
 // Apply the engine to the target environment
 func (e *TerraformEngine) Apply(appSpec *app_spec_schema.Application) (string, error) {
 	tfDeployment := NewTerraformDeployment(e, appSpec.Name)
 
-	// Create platform variables ahead of time
-	for varName, variableSpec := range e.platform.Variables {
-		tfDeployment.terraformVariables[varName] = cdktf.NewTerraformVariable(tfDeployment.stack, jsii.String(varName), &cdktf.TerraformVariableConfig{
-			Description: jsii.String(variableSpec.Description),
-			Default:     variableSpec.Default,
-			Type:        jsii.String(variableSpec.Type),
-		})
+	// Create platform variables
+	tfDeployment.createPlatformVariables()
+
+	// Process service identities first (needed by other resources)
+	serviceInputs, err := tfDeployment.processServiceIdentities(appSpec)
+	if err != nil {
+		return "", err
 	}
 
-	// Prepare service inputs and identities
+	// Process each resource type and collect environment variables they export to services
+	allServiceEnvs := map[string][]interface{}{}
+
+	// Process bucket resources
+	if len(appSpec.BucketIntents) > 0 {
+		bucketEnvs, err := tfDeployment.processBucketResources(appSpec)
+		if err != nil {
+			return "", err
+		}
+		// Merge bucket environment variable exports
+		for serviceName, envs := range bucketEnvs {
+			allServiceEnvs[serviceName] = append(allServiceEnvs[serviceName], envs...)
+		}
+	}
+
+	// Process database resources
+	if len(appSpec.DatabaseIntents) > 0 {
+		databaseEnvs, err := tfDeployment.processDatabaseResources(appSpec)
+		if err != nil {
+			return "", err
+		}
+		// Merge database environment variable exports
+		for serviceName, envs := range databaseEnvs {
+			allServiceEnvs[serviceName] = append(allServiceEnvs[serviceName], envs...)
+		}
+	}
+
+	// Process service resources (needs environment variables from other resources)
+	if len(appSpec.ServiceIntents) > 0 {
+		err = tfDeployment.processServiceResources(appSpec, serviceInputs, allServiceEnvs)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// Process entrypoint resources
+	if len(appSpec.EntrypointIntents) > 0 {
+		err = tfDeployment.processEntrypointResources(appSpec)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// Resolve resource tokens for all created resources
 	resourceIntents := appSpec.GetResourceIntents()
-
-	serviceInputs := map[string]*NitricServiceVariables{}
-	for intentName, resourceIntent := range resourceIntents {
-		var serviceIntent *app_spec_schema.ServiceIntent
-		switch resourceIntent.(type) {
-		case *app_spec_schema.ServiceIntent:
-			serviceIntent = resourceIntent.(*app_spec_schema.ServiceIntent)
-		default:
-			continue
-		}
-
-		spec, err := e.platform.GetServiceBlueprint(serviceIntent.GetSubType())
-		if err != nil {
-			return "", fmt.Errorf("could not find platform type for %s.%s: %w", serviceIntent.GetType(), serviceIntent.GetSubType(), err)
-		}
-		plug, err := e.resolvePlugin(spec.ResourceBlueprint)
-		if err != nil {
-			return "", err
-		}
-
-		nitricVar, err := tfDeployment.resolveService(intentName, serviceIntent, spec, plug)
-		if err != nil {
-			return "", err
-		}
-
-		serviceInputs[intentName] = nitricVar
-	}
-
-	serviceEnvs := map[string][]interface{}{}
-
-	// Resolve non-service/non-entrypoint/non-bucket modules
-	for intentName, resourceIntent := range resourceIntents {
-		resourceType := resourceIntent.GetType()
-
-		if resourceType == "service" || resourceType == "entrypoint" || resourceType == "bucket" {
-			continue
-		}
-
-		spec, err := e.platform.GetResourceBlueprint(resourceIntent.GetType(), resourceIntent.GetSubType())
-		if err != nil {
-			return "", fmt.Errorf("could not find platform type for %s.%s: %w", resourceIntent.GetType(), resourceIntent.GetSubType(), err)
-		}
-		plug, err := e.resolvePlugin(spec)
-		if err != nil {
-			return "", err
-		}
-
-		servicesInput := map[string]any{}
-		if access, ok := resourceIntent.GetAccess(); ok {
-			for serviceName, actions := range access {
-				idMap, ok := tfDeployment.serviceIdentities[serviceName]
-				if !ok {
-					return "", fmt.Errorf("could not give access to %s %s: service %s not found", resourceIntent.GetType(), intentName, serviceName)
-				}
-
-				servicesInput[serviceName] = map[string]interface{}{
-					"actions":    jsii.Strings(actions...),
-					"identities": idMap,
-				}
-			}
-		}
-
-		nitricVar := map[string]any{
-			"name":     intentName,
-			"stack_id": tfDeployment.stackId.Result(),
-			"services": servicesInput,
-		}
-
-		// Create terraform variables for intent for a spec
-		tfDeployment.createVariablesForIntent(intentName, spec)
-
-		tfDeployment.terraformResources[intentName] = cdktf.NewTerraformHclModule(tfDeployment.stack, jsii.String(intentName), &cdktf.TerraformHclModuleConfig{
-			// TODO: This assumes that the plugin is resolvable as a URI
-			Source: jsii.String(plug.Deployment.Terraform),
-			Variables: &map[string]interface{}{
-				"nitric": nitricVar,
-			},
-		})
-
-		for serviceName, _ := range serviceInputs {
-			env := cdktf.Fn_Try(&[]interface{}{tfDeployment.terraformResources[intentName].Get(jsii.Sprintf("nitric.exports.services.%s.env", serviceName)), map[string]interface{}{}})
-			serviceEnvs[serviceName] = append(serviceEnvs[serviceName], env)
-		}
-	}
-
-	// Resolve bucket modules
-	for intentName, bucketIntent := range appSpec.BucketIntents {
-
-		contentPath := ""
-		if bucketIntent != nil {
-			contentPath = bucketIntent.ContentPath
-		}
-
-		spec, err := e.platform.GetResourceBlueprint(bucketIntent.GetType(), bucketIntent.GetSubType())
-		if err != nil {
-			return "", fmt.Errorf("could not find platform type for %s.%s: %w", bucketIntent.GetType(), bucketIntent.GetSubType(), err)
-		}
-		plug, err := e.resolvePlugin(spec)
-		if err != nil {
-			return "", err
-		}
-
-		servicesInput := map[string]any{}
-		if access, ok := bucketIntent.GetAccess(); ok {
-			for serviceName, actions := range access {
-				idMap, ok := tfDeployment.serviceIdentities[serviceName]
-				if !ok {
-					return "", fmt.Errorf("could not give access to bucket %s: service %s not found", intentName, serviceName)
-				}
-
-				servicesInput[serviceName] = map[string]interface{}{
-					"actions":    jsii.Strings(actions...),
-					"identities": idMap,
-				}
-			}
-		}
-
-		nitricVar := map[string]any{
-			"name":         intentName,
-			"stack_id":     tfDeployment.stackId.Result(),
-			"content_path": contentPath,
-			"services":     servicesInput,
-		}
-
-		// Create terraform variables for intent for a spec
-		tfDeployment.createVariablesForIntent(intentName, spec)
-
-		tfDeployment.terraformResources[intentName] = cdktf.NewTerraformHclModule(tfDeployment.stack, jsii.String(intentName), &cdktf.TerraformHclModuleConfig{
-			// TODO: This assumes that the plugin is resolvable as a URI
-			Source: jsii.String(plug.Deployment.Terraform),
-			Variables: &map[string]interface{}{
-				"nitric": nitricVar,
-			},
-		})
-
-		for serviceName, _ := range serviceInputs {
-			env := cdktf.Fn_Try(&[]interface{}{tfDeployment.terraformResources[intentName].Get(jsii.Sprintf("nitric.exports.services.%s.env", serviceName)), map[string]interface{}{}})
-			serviceEnvs[serviceName] = append(serviceEnvs[serviceName], env)
-		}
-	}
-
-	// Resolve service modules
-	for intentName, resourceIntent := range appSpec.ServiceIntents {
-		spec, err := e.platform.GetResourceBlueprint(resourceIntent.GetType(), resourceIntent.GetSubType())
-		if err != nil {
-			return "", fmt.Errorf("could not find platform type for %s.%s: %w", resourceIntent.GetType(), resourceIntent.GetSubType(), err)
-		}
-		plug, err := e.resolvePlugin(spec)
-		if err != nil {
-			return "", err
-		}
-
-		var nitricVar *NitricServiceVariables = serviceInputs[intentName]
-
-		origEnv := nitricVar.Env
-
-		mergedEnv := serviceEnvs[intentName]
-		allEnv := append(mergedEnv, origEnv)
-
-		nitricVar.Env = cdktf.Fn_Merge(&allEnv)
-
-		tfDeployment.createVariablesForIntent(intentName, spec)
-
-		tfDeployment.terraformResources[intentName] = cdktf.NewTerraformHclModule(tfDeployment.stack, jsii.String(intentName), &cdktf.TerraformHclModuleConfig{
-			// TODO: This assumes that the plugin is resolvable as a URI
-			Source: jsii.String(plug.Deployment.Terraform),
-			Variables: &map[string]interface{}{
-				"nitric": nitricVar,
-			},
-		})
-	}
-
-	// Resolve entrypoint modules
-	for intentName, resourceIntent := range appSpec.EntrypointIntents {
-		spec, err := e.platform.GetResourceBlueprint(resourceIntent.GetType(), resourceIntent.GetSubType())
-		if err != nil {
-			return "", fmt.Errorf("could not find platform type for %s.%s: %w", resourceIntent.GetType(), resourceIntent.GetSubType(), err)
-		}
-		plug, err := e.resolvePlugin(spec)
-		if err != nil {
-			return "", err
-		}
-
-		nitricVar, err := tfDeployment.resolveEntrypointNitricVar(intentName, appSpec, resourceIntent)
-		if err != nil {
-			return "", err
-		}
-
-		tfDeployment.createVariablesForIntent(intentName, spec)
-
-		tfDeployment.terraformResources[intentName] = cdktf.NewTerraformHclModule(tfDeployment.stack, jsii.String(intentName), &cdktf.TerraformHclModuleConfig{
-			// TODO: This assumes that the plugin is resolvable as a URI
-			Source: jsii.String(plug.Deployment.Terraform),
-			Variables: &map[string]interface{}{
-				"nitric": nitricVar,
-			},
-		})
-	}
-
-	// Resolve resource tokens
 	for resourceName, resourceIntent := range resourceIntents {
 		resourceSpec, err := e.platform.GetResourceBlueprint(resourceIntent.GetType(), resourceIntent.GetSubType())
 		if err != nil {
@@ -696,14 +134,13 @@ func (e *TerraformEngine) Apply(appSpec *app_spec_schema.Application) (string, e
 		if !ok {
 			return "", fmt.Errorf("infra resource %s not found", infraName)
 		}
-		// TODO: This is overloading this method as infra-name is not usable in this context as infra cannot resolve `self` tokens
 		err := tfDeployment.resolveTokensForModule(infraName, infraSpec, infra)
 		if err != nil {
 			return "", err
 		}
 	}
 
-	// resolve dependencies for all created modules
+	// Resolve dependencies for all created modules
 	for resourceName, resource := range resourceIntents {
 		resourceSpec, err := e.platform.GetResourceBlueprint(resource.GetType(), resource.GetSubType())
 		if err != nil {
@@ -716,7 +153,7 @@ func (e *TerraformEngine) Apply(appSpec *app_spec_schema.Application) (string, e
 		}
 	}
 
-	// resolve dependencies for all created infrastructure
+	// Resolve dependencies for all created infrastructure
 	for infraName, infra := range tfDeployment.terraformInfraResources {
 		infraSpec, ok := e.platform.InfraSpecs[infraName]
 		if !ok {
@@ -729,7 +166,7 @@ func (e *TerraformEngine) Apply(appSpec *app_spec_schema.Application) (string, e
 		}
 	}
 
-	tfDeployment.app.Synth()
+	tfDeployment.Synth()
 
 	return filepath.Join(e.outputDir, "stacks", appSpec.Name), nil
 }

--- a/engines/terraform/variables.go
+++ b/engines/terraform/variables.go
@@ -1,0 +1,30 @@
+package terraform
+
+import (
+	"github.com/aws/jsii-runtime-go"
+	"github.com/hashicorp/terraform-cdk-go/cdktf"
+)
+
+func (td *TerraformDeployment) createVariablesForIntent(intentName string, spec *ResourceBlueprint) {
+	for varName, variable := range spec.Variables {
+		if td.instancedTerraformVariables[intentName] == nil {
+			td.instancedTerraformVariables[intentName] = make(map[string]cdktf.TerraformVariable)
+		}
+
+		td.instancedTerraformVariables[intentName][varName] = cdktf.NewTerraformVariable(td.stack, jsii.Sprintf("%s_%s", intentName, varName), &cdktf.TerraformVariableConfig{
+			Description: jsii.String(variable.Description),
+			Type:        jsii.String(variable.Type),
+			Default:     variable.Default,
+		})
+	}
+}
+
+func (td *TerraformDeployment) createPlatformVariables() {
+	for varName, variableSpec := range td.engine.platform.Variables {
+		td.terraformVariables[varName] = cdktf.NewTerraformVariable(td.stack, jsii.String(varName), &cdktf.TerraformVariableConfig{
+			Description: jsii.String(variableSpec.Description),
+			Default:     variableSpec.Default,
+			Type:        jsii.String(variableSpec.Type),
+		})
+	}
+}


### PR DESCRIPTION
also includes a crude breakup of the current apply function. Still needs more refactoring to increase test-ability.