### PR TITLE
Remove the default backend from out terraform output.

### DIFF
--- a/engines/terraform/backend.go
+++ b/engines/terraform/backend.go
@@ -1,0 +1,28 @@
+package terraform
+
+import (
+	"github.com/aws/constructs-go/constructs/v10"
+	"github.com/aws/jsii-runtime-go"
+	"github.com/hashicorp/terraform-cdk-go/cdktf"
+)
+
+// NilTerraformBackend prevents cdktf from automatically defining a backend in the output Terraform configuration.
+type NilTerraformBackend struct {
+	cdktf.TerraformBackend
+}
+
+// ToTerraform returns empty config to ensure an undefined backend in the output.
+func (t *NilTerraformBackend) ToTerraform() interface{} {
+	return map[string]interface{}{}
+}
+
+// NewNilTerraformBackend creates a nil backend that prevents the backend field from being defined in the output terraform.
+// We have this here as there is no way to disable the backend in cdktf.
+// https://github.com/hashicorp/terraform-cdk/issues/2435
+func NewNilTerraformBackend(app constructs.Construct, name *string) *NilTerraformBackend {
+	backend := &NilTerraformBackend{}
+
+	cdktf.NewTerraformBackend_Override(backend, app, jsii.String("nil"), name)
+
+	return backend
+}

--- a/engines/terraform/terraform.go
+++ b/engines/terraform/terraform.go
@@ -10,7 +10,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/aws/jsii-runtime-go"
 	random "github.com/cdktf/cdktf-provider-random-go/random/v11/provider"
 	"github.com/cdktf/cdktf-provider-random-go/random/v11/stringresource"
@@ -224,12 +223,10 @@ func (tf *TerraformDeployment) resolveTokensForModule(intentName string, resourc
 	return nil
 }
 
-
 func NewTerraformDeployment(engine *TerraformEngine, stackName string) *TerraformDeployment {
 	app := cdktf.NewApp(&cdktf.AppConfig{
 		Outdir: jsii.String(engine.outputDir),
 	})
-	// stack := NewTerraformStackSansBackend(app, jsii.String(stackName))
 
 	stack := cdktf.NewTerraformStack(app, jsii.String(stackName))
 

--- a/engines/terraform/terraform.go
+++ b/engines/terraform/terraform.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/aws/jsii-runtime-go"
 	random "github.com/cdktf/cdktf-provider-random-go/random/v11/provider"
 	"github.com/cdktf/cdktf-provider-random-go/random/v11/stringresource"
@@ -223,11 +224,17 @@ func (tf *TerraformDeployment) resolveTokensForModule(intentName string, resourc
 	return nil
 }
 
+
 func NewTerraformDeployment(engine *TerraformEngine, stackName string) *TerraformDeployment {
 	app := cdktf.NewApp(&cdktf.AppConfig{
 		Outdir: jsii.String(engine.outputDir),
 	})
+	// stack := NewTerraformStackSansBackend(app, jsii.String(stackName))
+
 	stack := cdktf.NewTerraformStack(app, jsii.String(stackName))
+
+	// Create a new nil backend for the stack
+	NewNilTerraformBackend(stack, jsii.String("nil_backend"))
 
 	random.NewRandomProvider(stack, jsii.String("random"), &random.RandomProviderConfig{})
 


### PR DESCRIPTION
The default backend was preventing users from defining their own backend.tf file inline with generated terraform. This should now be possible as we will never generate a default backend as part of out terraform output.