### PR TITLE
Fixes CDN domain deployment and API domain parent

### DIFF
--- a/cloud/aws/deploy/api.go
+++ b/cloud/aws/deploy/api.go
@@ -250,7 +250,11 @@ func (a *NitricAwsPulumiProvider) Api(ctx *pulumi.Context, parent pulumi.Resourc
 }
 
 func (a *NitricAwsPulumiProvider) createApiDomainName(ctx *pulumi.Context, name string, domainName string, stage *apigatewayv2.Stage, api *apigatewayv2.Api) error {
-	domain, err := a.newPulumiDomainName(ctx, domainName)
+	domain, err := a.newPulumiDomainName(ctx, domainArgs{
+		DomainName: domainName,
+		// Required for backwards compatibility with provider versions < 1.26.1
+		AliasName: name,
+	})
 	if err != nil {
 		return err
 	}

--- a/cloud/aws/deploy/api.go
+++ b/cloud/aws/deploy/api.go
@@ -267,7 +267,7 @@ func (a *NitricAwsPulumiProvider) createApiDomainName(ctx *pulumi.Context, name 
 			SecurityPolicy: pulumi.String("TLS_1_2"),
 			CertificateArn: domain.CertificateValidation.CertificateArn,
 		},
-	})
+	}, pulumi.Parent(domain))
 	if err != nil {
 		return err
 	}
@@ -277,7 +277,7 @@ func (a *NitricAwsPulumiProvider) createApiDomainName(ctx *pulumi.Context, name 
 		ApiId:      api.ID(),
 		DomainName: apiDomainName.DomainName,
 		Stage:      stage.Name,
-	}, pulumi.DependsOn([]pulumi.Resource{stage}))
+	}, pulumi.DependsOn([]pulumi.Resource{stage}), pulumi.Parent(domain))
 	if err != nil {
 		return err
 	}
@@ -298,7 +298,7 @@ func (a *NitricAwsPulumiProvider) createApiDomainName(ctx *pulumi.Context, name 
 				EvaluateTargetHealth: pulumi.Bool(false),
 			},
 		},
-	}, pulumi.DependsOn([]pulumi.Resource{domain}))
+	}, pulumi.DependsOn([]pulumi.Resource{domain}), pulumi.Parent(domain))
 	if err != nil {
 		return err
 	}

--- a/cloud/aws/deploy/api.go
+++ b/cloud/aws/deploy/api.go
@@ -298,7 +298,7 @@ func (a *NitricAwsPulumiProvider) createApiDomainName(ctx *pulumi.Context, name 
 				EvaluateTargetHealth: pulumi.Bool(false),
 			},
 		},
-	}, pulumi.DependsOn([]pulumi.Resource{domain}), pulumi.Parent(domain))
+	}, pulumi.Parent(domain))
 	if err != nil {
 		return err
 	}

--- a/cloud/aws/deploy/website.go
+++ b/cloud/aws/deploy/website.go
@@ -335,7 +335,7 @@ func (a *NitricAwsPulumiProvider) deployCloudfrontDistribution(ctx *pulumi.Conte
 	if domainName != "" {
 		aliases = []string{domainName}
 
-		domain, err := a.newPulumiDomainName(ctx, domainName)
+		domain, err := a.newPulumiDomainName(ctx, domainArgs{DomainName: domainName})
 		if err != nil {
 			return err
 		}

--- a/cloud/aws/deploy/website.go
+++ b/cloud/aws/deploy/website.go
@@ -335,7 +335,10 @@ func (a *NitricAwsPulumiProvider) deployCloudfrontDistribution(ctx *pulumi.Conte
 	if domainName != "" {
 		aliases = []string{domainName}
 
-		domain, err := a.newPulumiDomainName(ctx, domainArgs{DomainName: domainName})
+		domain, err := a.newPulumiDomainName(ctx, domainArgs{
+			DomainName:  domainName,
+			IsCDNDomain: true,
+		})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Addresses issues with CDN domain deployment and API domain resource parenting.

- Deploys ACM certificates for CDN domains exclusively in the us-east-1 region.
- Corrects resource parenting for API domains.
- Introduces alias for the domain certificate to ensure compatibility with older provider versions.

This change ensures non-breaking CDN domain deployments and proper resource management.