### PR TITLE
docs: excludes comparison docs from search indexing

### DIFF
--- a/docs/contentlayer.config.ts
+++ b/docs/contentlayer.config.ts
@@ -39,6 +39,10 @@ const baseFields: FieldDefs = {
     type: 'string',
     description: 'The canonical url of the doc, if different from the url',
   },
+  noindex: {
+    type: 'boolean',
+    description: 'Prevent search engines from indexing this page',
+  },
 }
 
 const computedFields: ComputedFields = {

--- a/docs/docs/misc/comparison/ampt.mdx
+++ b/docs/docs/misc/comparison/ampt.mdx
@@ -1,5 +1,6 @@
 ---
 description: 'Comparison to Ampt'
+noindex: true
 ---
 
 # Ampt vs. Nitric

--- a/docs/docs/misc/comparison/aws-cdk.mdx
+++ b/docs/docs/misc/comparison/aws-cdk.mdx
@@ -1,5 +1,6 @@
 ---
 description: 'Comparison to AWS CDK'
+noindex: true
 ---
 
 # AWS CDK vs. Nitric

--- a/docs/docs/misc/comparison/aws-sam.mdx
+++ b/docs/docs/misc/comparison/aws-sam.mdx
@@ -1,5 +1,6 @@
 ---
 description: 'Comparison to AWS Serverless Application Model (SAM)'
+noindex: true
 ---
 
 # AWS SAM vs. Nitric

--- a/docs/docs/misc/comparison/bicep.mdx
+++ b/docs/docs/misc/comparison/bicep.mdx
@@ -1,5 +1,6 @@
 ---
 description: 'Comparison to Bicep'
+noindex: true
 ---
 
 # Bicep vs. Nitric

--- a/docs/docs/misc/comparison/encore.mdx
+++ b/docs/docs/misc/comparison/encore.mdx
@@ -1,5 +1,6 @@
 ---
 description: 'Comparison to Encore'
+noindex: true
 ---
 
 # Encore vs. Nitric

--- a/docs/docs/misc/comparison/gcp-deployment-manager.mdx
+++ b/docs/docs/misc/comparison/gcp-deployment-manager.mdx
@@ -1,5 +1,6 @@
 ---
 description: 'Comparison to Google Cloud Deployment Manager'
+noindex: true
 ---
 
 # Google Cloud Deployment Manager vs. Nitric

--- a/docs/docs/misc/comparison/pulumi.mdx
+++ b/docs/docs/misc/comparison/pulumi.mdx
@@ -1,5 +1,6 @@
 ---
 description: 'Comparison to Pulumi'
+noindex: true
 ---
 
 # Pulumi vs. Nitric

--- a/docs/docs/misc/comparison/sst.mdx
+++ b/docs/docs/misc/comparison/sst.mdx
@@ -1,5 +1,6 @@
 ---
 description: 'Comparison to SST'
+noindex: true
 ---
 
 # SST vs. Nitric

--- a/docs/docs/misc/comparison/terraform.mdx
+++ b/docs/docs/misc/comparison/terraform.mdx
@@ -1,5 +1,6 @@
 ---
 description: 'Comparison to Terraform'
+noindex: true
 ---
 
 # Terraform vs. Nitric

--- a/docs/src/app/(sitemaps)/sitemap-0.xml/route.ts
+++ b/docs/src/app/(sitemaps)/sitemap-0.xml/route.ts
@@ -22,12 +22,14 @@ export async function GET() {
     priority: 0.7,
   }))
 
-  const docPages: SitemapItem[] = allDocuments.map((page) => ({
-    loc: page.slug === '' ? URL : `${URL}/${page.slug}`,
-    lastmod: new Date(page.lastModified).toISOString(),
-    changefreq: 'daily',
-    priority: 0.7,
-  }))
+  const docPages: SitemapItem[] = allDocuments
+    .filter((page) => !page.slug.startsWith('misc/comparison/'))
+    .map((page) => ({
+      loc: page.slug === '' ? URL : `${URL}/${page.slug}`,
+      lastmod: new Date(page.lastModified).toISOString(),
+      changefreq: 'daily',
+      priority: 0.7,
+    }))
 
   const allPagesSorted = [...pages, ...docPages].sort((a, b) =>
     a.loc < b.loc ? -1 : 1,

--- a/docs/src/app/[[...slug]]/page.tsx
+++ b/docs/src/app/[[...slug]]/page.tsx
@@ -72,6 +72,12 @@ export async function generateMetadata({
     alternates: {
       canonical: doc.canonical_url ? doc.canonical_url : url,
     },
+    ...(doc.noindex && {
+      robots: {
+        index: false,
+        follow: false,
+      },
+    }),
   }
 }
 

--- a/docs/src/app/robots.ts
+++ b/docs/src/app/robots.ts
@@ -13,10 +13,13 @@ export default function robots(): MetadataRoute.Robots {
 
   // production robots.txt
   return {
-    rules: {
-      userAgent: '*',
-      allow: '/',
-    },
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: '/misc/comparison/',
+      },
+    ],
     host: 'https://nitric.io/docs',
     sitemap: 'https://nitric.io/docs/sitemap.xml',
   }


### PR DESCRIPTION
Hides comparison documentation pages from search engine indexing and the sitemap.

This prevents these pages from appearing in search results.

The changes include:

- Adding a `noindex` field to the contentlayer configuration
- Setting `noindex: true` in the frontmatter of comparison MDX documents
- Updating the sitemap generation to exclude comparison pages
- Adding a disallow rule to the robots.txt for the `/misc/comparison/` path

Closes NIT-11