### PR TITLE
fix(aws): auto-select SSM parameter tier to avoid 4096-char limit

### DIFF
--- a/cloud/aws/deploy/resources.go
+++ b/cloud/aws/deploy/resources.go
@@ -164,11 +164,21 @@ func (a *NitricAwsPulumiProvider) resourcesStore(ctx *pulumi.Context) error {
 		return string(indexJson), nil
 	}).(pulumi.StringOutput)
 
+	// Auto-select SSM parameter tier based on value size.
+	// Standard tier supports up to 4,096 chars; Advanced supports up to 8,192.
+	ssmTier := resourceIndexJson.ApplyT(func(val string) string {
+		if len(val) > 4096 {
+			return "Advanced"
+		}
+		return "Standard"
+	}).(pulumi.StringOutput)
+
 	_, err := ssm.NewParameter(ctx, "nitric-resource-index", &ssm.ParameterArgs{
 		// Create a deterministic name for the resource index
 		Name:     pulumi.Sprintf("/nitric/%s/resource-index", a.StackId),
 		DataType: pulumi.String("text"),
 		Type:     pulumi.String("String"),
+		Tier:     ssmTier,
 		// Store the nitric resource index serialized as a JSON string
 		Value: resourceIndexJson,
 	})

--- a/cloud/aws/deploytf/.nitric/modules/parameter/main.tf
+++ b/cloud/aws/deploytf/.nitric/modules/parameter/main.tf
@@ -13,6 +13,7 @@ resource "aws_ssm_parameter" "text_parameter" {
   type      = "String"
   value     = var.parameter_value
   data_type = "text"
+  tier      = var.parameter_tier
 }
 
 # Create the access policy

--- a/cloud/aws/deploytf/.nitric/modules/parameter/variables.tf
+++ b/cloud/aws/deploytf/.nitric/modules/parameter/variables.tf
@@ -12,3 +12,14 @@ variable "parameter_value" {
   description = "The text value of the parameter"
   type        = string
 }
+
+variable "parameter_tier" {
+  description = "The tier of the SSM parameter (Standard or Advanced). Standard supports up to 4,096 characters; Advanced supports up to 8,192 characters."
+  type        = string
+  default     = "Standard"
+
+  validation {
+    condition     = contains(["Standard", "Advanced"], var.parameter_tier)
+    error_message = "parameter_tier must be one of: Standard, Advanced."
+  }
+}

--- a/cloud/aws/deploytf/generated/parameter/Parameter.go
+++ b/cloud/aws/deploytf/generated/parameter/Parameter.go
@@ -36,6 +36,8 @@ type Parameter interface {
 	Node() constructs.Node
 	ParameterName() *string
 	SetParameterName(val *string)
+	ParameterTier() *string
+	SetParameterTier(val *string)
 	ParameterValue() *string
 	SetParameterValue(val *string)
 	// Experimental.
@@ -169,6 +171,16 @@ func (j *jsiiProxy_Parameter) ParameterName() *string {
 	return returns
 }
 
+func (j *jsiiProxy_Parameter) ParameterTier() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"parameterTier",
+		&returns,
+	)
+	return returns
+}
+
 func (j *jsiiProxy_Parameter) ParameterValue() *string {
 	var returns *string
 	_jsii_.Get(
@@ -291,6 +303,14 @@ func (j *jsiiProxy_Parameter)SetParameterName(val *string) {
 	_jsii_.Set(
 		j,
 		"parameterName",
+		val,
+	)
+}
+
+func (j *jsiiProxy_Parameter)SetParameterTier(val *string) {
+	_jsii_.Set(
+		j,
+		"parameterTier",
 		val,
 	)
 }

--- a/cloud/aws/deploytf/generated/parameter/ParameterConfig.go
+++ b/cloud/aws/deploytf/generated/parameter/ParameterConfig.go
@@ -19,5 +19,8 @@ type ParameterConfig struct {
 	ParameterName *string `field:"required" json:"parameterName" yaml:"parameterName"`
 	// The text value of the parameter.
 	ParameterValue *string `field:"required" json:"parameterValue" yaml:"parameterValue"`
+	// The tier of the SSM parameter (Standard or Advanced).
+	// Docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter#tier
+	ParameterTier *string `field:"optional" json:"parameterTier" yaml:"parameterTier"`
 }
 

--- a/cloud/aws/deploytf/resources.go
+++ b/cloud/aws/deploytf/resources.go
@@ -76,10 +76,18 @@ func (a *NitricAwsTerraformProvider) ResourcesStore(stack cdktf.TerraformStack, 
 		return fmt.Errorf("failed to marshal resource index: %w", err)
 	}
 
+	// Auto-select SSM parameter tier based on value size.
+	// Standard tier supports up to 4,096 chars; Advanced supports up to 8,192.
+	parameterTier := "Standard"
+	if len(indexJson) > 4096 {
+		parameterTier = "Advanced"
+	}
+
 	parameter.NewParameter(stack, jsii.String("nitric_resources"), &parameter.ParameterConfig{
 		ParameterName:   jsii.Sprintf("/nitric/%s/resource-index", *a.Stack.StackIdOutput()),
 		ParameterValue:  jsii.String(string(indexJson)),
 		AccessRoleNames: jsii.Strings(accessRoleNames...),
+		ParameterTier:   jsii.String(parameterTier),
 	})
 
 	return nil


### PR DESCRIPTION
# Description

When a Nitric stack grows large enough, the resource-index JSON written to AWS SSM Parameter Store exceeds the Standard tier's 4,096-character limit, causing deployment failures with a `ParameterValueTooLong` or tier-related validation error.

This change detects the JSON size at deploy time and automatically selects the appropriate SSM tier:
- ≤ 4,096 bytes → `Standard` (default, no cost impact)
- > 4,096 bytes → `Advanced` (~$0.05/parameter/month)

Applies to both the Pulumi provider (`cloud/aws/deploy/resources.go`) and the Terraform CDKTF provider (`cloud/aws/deploytf/`). Small stacks are unaffected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

This is a simple conditional change — `go build` and `go vet` pass on the affected packages. No unit tests added as the deployment provider packages (`deploy/`, `deploytf/`) have no existing test coverage.