### PR TITLE
feat(aws): add configurable tagging API resource resolver

### DIFF
--- a/cloud/aws/common/config.go
+++ b/cloud/aws/common/config.go
@@ -17,9 +17,18 @@
 package common
 
 import (
+	"fmt"
+
 	"github.com/imdario/mergo"
 	"github.com/mitchellh/mapstructure"
 	"github.com/nitrictech/nitric/cloud/common/deploy/config"
+)
+
+const (
+	// ResourceResolverSSM uses SSM Parameter Store for runtime resource discovery (default).
+	ResourceResolverSSM = "ssm"
+	// ResourceResolverTagging uses the AWS Resource Groups Tagging API for runtime resource discovery.
+	ResourceResolverTagging = "tagging"
 )
 
 type AwsApiConfig struct {
@@ -142,7 +151,11 @@ func ConfigFromAttributes(attributes map[string]interface{}) (*AwsConfig, error)
 
 	// Default resource resolver to SSM if not specified
 	if awsConfig.ResourceResolver == "" {
-		awsConfig.ResourceResolver = "ssm"
+		awsConfig.ResourceResolver = ResourceResolverSSM
+	}
+
+	if awsConfig.ResourceResolver != ResourceResolverSSM && awsConfig.ResourceResolver != ResourceResolverTagging {
+		return nil, fmt.Errorf("invalid resource-resolver value %q: must be %q or %q", awsConfig.ResourceResolver, ResourceResolverSSM, ResourceResolverTagging)
 	}
 
 	if awsConfig.Apis == nil {

--- a/cloud/aws/common/config.go
+++ b/cloud/aws/common/config.go
@@ -64,6 +64,7 @@ type AuroraRdsClusterConfig struct {
 
 type AwsConfig struct {
 	ScheduleTimezone                      string `mapstructure:"schedule-timezone,omitempty"`
+	ResourceResolver                      string `mapstructure:"resource-resolver,omitempty"`
 	Import                                AwsImports
 	Refresh                               bool
 	Apis                                  map[string]*AwsApiConfig
@@ -137,6 +138,11 @@ func ConfigFromAttributes(attributes map[string]interface{}) (*AwsConfig, error)
 	if awsConfig.ScheduleTimezone == "" {
 		// default to UTC
 		awsConfig.ScheduleTimezone = "UTC"
+	}
+
+	// Default resource resolver to SSM if not specified
+	if awsConfig.ResourceResolver == "" {
+		awsConfig.ResourceResolver = "ssm"
 	}
 
 	if awsConfig.Apis == nil {

--- a/cloud/aws/common/config_test.go
+++ b/cloud/aws/common/config_test.go
@@ -1,0 +1,96 @@
+// Copyright 2021 Nitric Technologies Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+)
+
+func TestConfigFromAttributes_ResourceResolver(t *testing.T) {
+	tests := []struct {
+		name        string
+		attrs       map[string]interface{}
+		wantValue   string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:      "defaults to ssm when not specified",
+			attrs:     map[string]interface{}{},
+			wantValue: ResourceResolverSSM,
+		},
+		{
+			name:      "accepts ssm explicitly",
+			attrs:     map[string]interface{}{"resource-resolver": "ssm"},
+			wantValue: ResourceResolverSSM,
+		},
+		{
+			name:      "accepts tagging",
+			attrs:     map[string]interface{}{"resource-resolver": "tagging"},
+			wantValue: ResourceResolverTagging,
+		},
+		{
+			name:        "rejects invalid value",
+			attrs:       map[string]interface{}{"resource-resolver": "taging"},
+			wantErr:     true,
+			errContains: "invalid resource-resolver",
+		},
+		{
+			name:        "rejects arbitrary string",
+			attrs:       map[string]interface{}{"resource-resolver": "something-else"},
+			wantErr:     true,
+			errContains: "invalid resource-resolver",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := ConfigFromAttributes(tt.attrs)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.errContains)
+				}
+				if tt.errContains != "" {
+					if !containsString(err.Error(), tt.errContains) {
+						t.Fatalf("expected error containing %q, got %q", tt.errContains, err.Error())
+					}
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if cfg.ResourceResolver != tt.wantValue {
+				t.Errorf("ResourceResolver = %q, want %q", cfg.ResourceResolver, tt.wantValue)
+			}
+		})
+	}
+}
+
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/cloud/aws/common/config_test.go
+++ b/cloud/aws/common/config_test.go
@@ -15,6 +15,7 @@
 package common
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -64,7 +65,7 @@ func TestConfigFromAttributes_ResourceResolver(t *testing.T) {
 					t.Fatalf("expected error containing %q, got nil", tt.errContains)
 				}
 				if tt.errContains != "" {
-					if !containsString(err.Error(), tt.errContains) {
+					if !strings.Contains(err.Error(), tt.errContains) {
 						t.Fatalf("expected error containing %q, got %q", tt.errContains, err.Error())
 					}
 				}
@@ -80,17 +81,4 @@ func TestConfigFromAttributes_ResourceResolver(t *testing.T) {
 			}
 		})
 	}
-}
-
-func containsString(s, substr string) bool {
-	return len(s) >= len(substr) && searchString(s, substr)
-}
-
-func searchString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/cloud/aws/deploy/batch.go
+++ b/cloud/aws/deploy/batch.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/nitrictech/nitric/cloud/aws/common"
 	"github.com/nitrictech/nitric/cloud/common/deploy/image"
 	"github.com/nitrictech/nitric/cloud/common/deploy/provider"
 	"github.com/nitrictech/nitric/cloud/common/deploy/tags"
@@ -364,10 +365,10 @@ func (p *NitricAwsPulumiProvider) Batch(ctx *pulumi.Context, parent pulumi.Resou
 				})
 			}
 
-			if p.AwsConfig.ResourceResolver == "tagging" {
+			if p.AwsConfig.ResourceResolver == common.ResourceResolverTagging {
 				jobDefinitionContainerProperties.Environment = append(jobDefinitionContainerProperties.Environment, EnvironmentVariable{
 					Name:  "NITRIC_AWS_RESOURCE_RESOLVER",
-					Value: "tagging",
+					Value: common.ResourceResolverTagging,
 				})
 			}
 

--- a/cloud/aws/deploy/batch.go
+++ b/cloud/aws/deploy/batch.go
@@ -364,6 +364,13 @@ func (p *NitricAwsPulumiProvider) Batch(ctx *pulumi.Context, parent pulumi.Resou
 				})
 			}
 
+			if p.AwsConfig.ResourceResolver == "tagging" {
+				jobDefinitionContainerProperties.Environment = append(jobDefinitionContainerProperties.Environment, EnvironmentVariable{
+					Name:  "NITRIC_AWS_RESOURCE_RESOLVER",
+					Value: "tagging",
+				})
+			}
+
 			if job.Requirements.Gpus > 0 {
 				jobDefinitionContainerProperties.ResourceRequirements = append(jobDefinitionContainerProperties.ResourceRequirements, ResourceRequirement{
 					Type:  "GPU",

--- a/cloud/aws/deploy/resources.go
+++ b/cloud/aws/deploy/resources.go
@@ -24,7 +24,7 @@ import (
 )
 
 func (a *NitricAwsPulumiProvider) resourcesStore(ctx *pulumi.Context) error {
-	if a.AwsConfig.ResourceResolver == "tagging" {
+	if a.AwsConfig.ResourceResolver == common.ResourceResolverTagging {
 		return nil
 	}
 

--- a/cloud/aws/deploy/resources.go
+++ b/cloud/aws/deploy/resources.go
@@ -24,6 +24,10 @@ import (
 )
 
 func (a *NitricAwsPulumiProvider) resourcesStore(ctx *pulumi.Context) error {
+	if a.AwsConfig.ResourceResolver == "tagging" {
+		return nil
+	}
+
 	// Build the AWS resource index from the provider information
 	// This will be used to store the ARNs/Identifiers of all resources created by the stack
 	bucketArnMap := pulumi.StringMap{}

--- a/cloud/aws/deploy/service.go
+++ b/cloud/aws/deploy/service.go
@@ -23,6 +23,7 @@ import (
 	"github.com/avast/retry-go"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/nitrictech/nitric/cloud/aws/common"
 	"github.com/nitrictech/nitric/cloud/common/deploy/image"
 	"github.com/nitrictech/nitric/cloud/common/deploy/provider"
 	"github.com/nitrictech/nitric/cloud/common/deploy/pulumix"
@@ -181,8 +182,8 @@ func (a *NitricAwsPulumiProvider) Service(ctx *pulumi.Context, parent pulumi.Res
 		envVars[k] = v
 	}
 
-	if a.AwsConfig.ResourceResolver == "tagging" {
-		envVars["NITRIC_AWS_RESOURCE_RESOLVER"] = pulumi.String("tagging")
+	if a.AwsConfig.ResourceResolver == common.ResourceResolverTagging {
+		envVars["NITRIC_AWS_RESOURCE_RESOLVER"] = pulumi.String(common.ResourceResolverTagging)
 	}
 
 	if a.JobQueue != nil {

--- a/cloud/aws/deploy/service.go
+++ b/cloud/aws/deploy/service.go
@@ -181,6 +181,10 @@ func (a *NitricAwsPulumiProvider) Service(ctx *pulumi.Context, parent pulumi.Res
 		envVars[k] = v
 	}
 
+	if a.AwsConfig.ResourceResolver == "tagging" {
+		envVars["NITRIC_AWS_RESOURCE_RESOLVER"] = pulumi.String("tagging")
+	}
+
 	if a.JobQueue != nil {
 		envVars["NITRIC_JOB_QUEUE_ARN"] = a.JobQueue.Arn
 	}

--- a/cloud/aws/deploytf/resources.go
+++ b/cloud/aws/deploytf/resources.go
@@ -25,6 +25,10 @@ import (
 )
 
 func (a *NitricAwsTerraformProvider) ResourcesStore(stack cdktf.TerraformStack, accessRoleNames []string) error {
+	if a.AwsConfig.ResourceResolver == "tagging" {
+		return nil
+	}
+
 	index := common.NewResourceIndex()
 
 	for name, bucket := range a.Buckets {

--- a/cloud/aws/deploytf/resources.go
+++ b/cloud/aws/deploytf/resources.go
@@ -25,7 +25,7 @@ import (
 )
 
 func (a *NitricAwsTerraformProvider) ResourcesStore(stack cdktf.TerraformStack, accessRoleNames []string) error {
-	if a.AwsConfig.ResourceResolver == "tagging" {
+	if a.AwsConfig.ResourceResolver == common.ResourceResolverTagging {
 		return nil
 	}
 

--- a/cloud/aws/deploytf/service.go
+++ b/cloud/aws/deploytf/service.go
@@ -54,10 +54,6 @@ func (a *NitricAwsTerraformProvider) Service(stack cdktf.TerraformStack, name st
 		"NITRIC_HTTP_PROXY_PORT": jsii.String(fmt.Sprint(3000)),
 	}
 
-	if a.AwsConfig.ResourceResolver == common.ResourceResolverTagging {
-		jsiiEnv["NITRIC_AWS_RESOURCE_RESOLVER"] = jsii.String(common.ResourceResolverTagging)
-	}
-
 	// TODO: Only apply to requesting services
 	if a.Rds != nil {
 		jsiiEnv["NITRIC_DATABASE_BASE_URL"] = jsii.Sprintf("postgres://%s:%s@%s:%s", *a.Rds.ClusterUsernameOutput(), *a.Rds.ClusterPasswordOutput(),
@@ -66,6 +62,12 @@ func (a *NitricAwsTerraformProvider) Service(stack cdktf.TerraformStack, name st
 
 	for k, v := range config.GetEnv() {
 		jsiiEnv[k] = jsii.String(v)
+	}
+
+	// Set after config.GetEnv() so the stack-level setting cannot be overridden by
+	// user env config, which would break resource discovery when SSM index creation was skipped.
+	if a.AwsConfig.ResourceResolver == common.ResourceResolverTagging {
+		jsiiEnv["NITRIC_AWS_RESOURCE_RESOLVER"] = jsii.String(common.ResourceResolverTagging)
 	}
 
 	serviceConfig := &service.ServiceConfig{

--- a/cloud/aws/deploytf/service.go
+++ b/cloud/aws/deploytf/service.go
@@ -53,6 +53,10 @@ func (a *NitricAwsTerraformProvider) Service(stack cdktf.TerraformStack, name st
 		"NITRIC_HTTP_PROXY_PORT": jsii.String(fmt.Sprint(3000)),
 	}
 
+	if a.AwsConfig.ResourceResolver == "tagging" {
+		jsiiEnv["NITRIC_AWS_RESOURCE_RESOLVER"] = jsii.String("tagging")
+	}
+
 	// TODO: Only apply to requesting services
 	if a.Rds != nil {
 		jsiiEnv["NITRIC_DATABASE_BASE_URL"] = jsii.Sprintf("postgres://%s:%s@%s:%s", *a.Rds.ClusterUsernameOutput(), *a.Rds.ClusterPasswordOutput(),

--- a/cloud/aws/deploytf/service.go
+++ b/cloud/aws/deploytf/service.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aws/jsii-runtime-go"
 	"github.com/hashicorp/terraform-cdk-go/cdktf"
+	"github.com/nitrictech/nitric/cloud/aws/common"
 	"github.com/nitrictech/nitric/cloud/aws/deploytf/generated/service"
 	"github.com/nitrictech/nitric/cloud/common/deploy/image"
 	"github.com/nitrictech/nitric/cloud/common/deploy/provider"
@@ -53,8 +54,8 @@ func (a *NitricAwsTerraformProvider) Service(stack cdktf.TerraformStack, name st
 		"NITRIC_HTTP_PROXY_PORT": jsii.String(fmt.Sprint(3000)),
 	}
 
-	if a.AwsConfig.ResourceResolver == "tagging" {
-		jsiiEnv["NITRIC_AWS_RESOURCE_RESOLVER"] = jsii.String("tagging")
+	if a.AwsConfig.ResourceResolver == common.ResourceResolverTagging {
+		jsiiEnv["NITRIC_AWS_RESOURCE_RESOLVER"] = jsii.String(common.ResourceResolverTagging)
 	}
 
 	// TODO: Only apply to requesting services

--- a/docs/docs/providers/pulumi/aws.mdx
+++ b/docs/docs/providers/pulumi/aws.mdx
@@ -166,6 +166,13 @@ region: my-aws-stack-region
 # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 schedule-timezone: Australia/Sydney # Available since v0.27.0
 
+# Configure how the runtime discovers deployed resources
+# 'ssm' (default) stores a resource index in SSM Parameter Store
+# 'tagging' uses the AWS Resource Groups Tagging API for runtime resource
+# discovery, avoiding the SSM parameter size limits (4KB standard / 8KB advanced)
+# which can be exceeded in stacks with many resources
+resource-resolver: tagging
+
 # Import existing AWS Resources
 # Available since v0.28.0
 import:

--- a/docs/docs/providers/terraform/aws.mdx
+++ b/docs/docs/providers/terraform/aws.mdx
@@ -146,6 +146,13 @@ import:
 # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 schedule-timezone: Australia/Sydney # Available since v0.27.0
 
+# Configure how the runtime discovers deployed resources
+# 'ssm' (default) stores a resource index in SSM Parameter Store
+# 'tagging' uses the AWS Resource Groups Tagging API for runtime resource
+# discovery, avoiding the SSM parameter size limits (4KB standard / 8KB advanced)
+# which can be exceeded in stacks with many resources
+resource-resolver: tagging
+
 # Apply configuration to nitric APIs
 apis:
   # The nitric name of the API to configure


### PR DESCRIPTION
# Description

Add a `resource-resolver: tagging` stack config option that allows the AWS provider to skip SSM Parameter Store for runtime resource discovery and use the AWS Resource Groups Tagging API instead.

**Problem:** The AWS provider stores a JSON resource index in SSM Parameter Store so Lambda functions can discover peer resources (buckets, topics, secrets, etc.) at runtime. SSM Standard tier has a **4,096-character limit**. A prior fix auto-selects Advanced tier (8KB limit), but this is still a ceiling that gets hit with larger stacks (e.g. 22 topics, 14 secrets, 7 buckets, 6 KV stores produces ~9KB of JSON).

**Solution:** The runtime already has a fully working `AwsTaggedResourceResolver` using the Resource Groups Tagging API, selectable via `NITRIC_AWS_RESOURCE_RESOLVER=tagging` env var. Resources are **already tagged** at deploy time with `x-nitric-<stackId>-name` and `x-nitric-<stackId>-type` tags. The `tag:GetResources` and `apigateway:GET` IAM permissions are **already granted** unconditionally to Lambda and Batch roles. This PR simply wires up a config option to skip SSM creation and pass the env var through.

**GCP and Azure don't have this problem** — they use tag/label-based resolution by default with no stored index. This change aligns the AWS provider with that pattern (opt-in for now).

### Stack file usage:

```yaml
# nitric-aws.yaml
provider: nitric/aws@latest
region: us-east-2
resource-resolver: tagging  # default: ssm
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Changes by file

| File | Change |
|------|--------|
| `cloud/aws/common/config.go` | Add `ResourceResolver` field, `ResourceResolverSSM`/`ResourceResolverTagging` constants, default to `"ssm"`, validate against known values |
| `cloud/aws/common/config_test.go` | Unit tests for config validation (default, explicit ssm, tagging, invalid values) |
| `cloud/aws/deploy/resources.go` | Early return when `"tagging"` — skip SSM parameter creation |
| `cloud/aws/deploy/service.go` | Set `NITRIC_AWS_RESOURCE_RESOLVER` env var on Lambda when `"tagging"` |
| `cloud/aws/deploy/batch.go` | Set `NITRIC_AWS_RESOURCE_RESOLVER` env var on Batch jobs when `"tagging"` |
| `cloud/aws/deploytf/resources.go` | Early return when `"tagging"` — skip SSM parameter creation |
| `cloud/aws/deploytf/service.go` | Set `NITRIC_AWS_RESOURCE_RESOLVER` env var on CDKTF services when `"tagging"` |
| `docs/docs/providers/pulumi/aws.mdx` | Document `resource-resolver` option in stack config reference |
| `docs/docs/providers/terraform/aws.mdx` | Document `resource-resolver` option in stack config reference |

### What is NOT changed

- **Runtime code** — already handles the env var toggle between SSM and tagging resolvers
- **IAM policies** — `tag:GetResources` and `apigateway:GET` already granted unconditionally
- **Tags infrastructure** — resources already tagged at deploy time
- **Default behavior** — existing stacks without this config option are completely unaffected

# Testing

## Unit tests

```
=== RUN   TestConfigFromAttributes_ResourceResolver
=== RUN   TestConfigFromAttributes_ResourceResolver/defaults_to_ssm_when_not_specified
=== RUN   TestConfigFromAttributes_ResourceResolver/accepts_ssm_explicitly
=== RUN   TestConfigFromAttributes_ResourceResolver/accepts_tagging
=== RUN   TestConfigFromAttributes_ResourceResolver/rejects_invalid_value
=== RUN   TestConfigFromAttributes_ResourceResolver/rejects_arbitrary_string
--- PASS: TestConfigFromAttributes_ResourceResolver (0.00s)
```

Existing runtime resource resolver tests also pass unchanged.

## Live deployment — Pulumi Provider (`nitric/aws@0.0.1`)

Built both provider binaries from this branch and deployed a test project with a bucket, topic, secret, and API to `us-east-2` with `resource-resolver: tagging`. **7/7 verification tests passed:**

| Test | Result |
|------|--------|
| No SSM parameter created | ✅ `ParameterNotFound` confirmed |
| Resources tagged via Tagging API | ✅ 7 resources found (bucket, topic, SNS, SFN, API, secret, Lambda, ECR) |
| Lambda `NITRIC_AWS_RESOURCE_RESOLVER=tagging` | ✅ Confirmed on `tagging-test_services-api-5b01437` |
| Health check (runtime resolver = tagging) | ✅ `{"status":"ok","resolver":"tagging"}` |
| Bucket write+read (resource resolved via tags) | ✅ Write and read succeeded |
| Topic publish (resource resolved via tags) | ✅ Published successfully |
| Secret put+access (resource resolved via tags) | ✅ Put and access succeeded |

## Generated Terraform inspection — CDKTF Provider (`nitric/awstf@0.0.1`)

| Test | Result |
|------|--------|
| No SSM `parameter` module in generated Terraform | ✅ Module list: `api`, `bucket`, `policy×3`, `secret`, `service`, `stack`, `topic` — no `parameter` |
| `NITRIC_AWS_RESOURCE_RESOLVER=tagging` in service env | ✅ Present in `cdk.tf.json` service module |